### PR TITLE
Simplified tier expansion algorithm

### DIFF
--- a/src/PrizePool.sol
+++ b/src/PrizePool.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.19;
 
+import "forge-std/console2.sol";
+
 import { IERC20 } from "openzeppelin/token/ERC20/IERC20.sol";
 import { SafeERC20 } from "openzeppelin/token/ERC20/utils/SafeERC20.sol";
 import { E, SD59x18, sd } from "prb-math/SD59x18.sol";
@@ -756,7 +758,10 @@ contract PrizePool is TieredLiquidityDistributor {
   /// @notice Calculates the number of tiers for the next draw
   /// @return The number of tiers for the next draw
   function _computeNextNumberOfTiers(uint32 _claimCount) internal pure returns (uint8) {
-    return _findHighestNumberOfTiersWithEstimatedPrizesLt(_claimCount*2);
+    // claimCount is expected to be the estimated number of claims for the current prize tier.
+    // We add 1 to the claim count for the canary tier
+    uint8 numTiers = _estimateTierUsingPrizeCountPerDraw(_claimCount) + 1;
+    return numTiers > MAXIMUM_NUMBER_OF_TIERS ? MAXIMUM_NUMBER_OF_TIERS : numTiers; // add new canary tier
   }
 
   function computeNextNumberOfTiers(uint32 _claimCount) external pure returns (uint8) {

--- a/src/PrizePool.sol
+++ b/src/PrizePool.sol
@@ -97,9 +97,7 @@ error CallerNotDrawManager(address caller, address drawManager);
  * @param firstDrawStartsAt The timestamp at which the first draw will start.
  * @param numberOfTiers The number of tiers to start with. Must be greater than or equal to the minimum number of tiers.
  * @param tierShares The number of shares to allocate to each tier
- * @param canaryShares The number of shares to allocate to the canary tier.
  * @param reserveShares The number of shares to allocate to the reserve.
- * @param claimExpansionThreshold The percentage of prizes that must be claimed to bump the number of tiers. This threshold is used for both standard prizes and canary prizes.
  * @param smoothing The amount of smoothing to apply to vault contributions. Must be less than 1. A value of 0 is no smoothing, while greater values smooth until approaching infinity
  */
 struct ConstructorParams {
@@ -110,9 +108,7 @@ struct ConstructorParams {
   uint64 firstDrawStartsAt;
   uint8 numberOfTiers;
   uint8 tierShares;
-  uint8 canaryShares;
   uint8 reserveShares;
-  UD2x18 claimExpansionThreshold;
   SD1x18 smoothing;
 }
 
@@ -224,9 +220,6 @@ contract PrizePool is TieredLiquidityDistributor {
   /// @notice The number of seconds between draws.
   uint32 public immutable drawPeriodSeconds;
 
-  /// @notice Percentage of prizes that must be claimed to bump the number of tiers.
-  UD2x18 public immutable claimExpansionThreshold;
-
   uint64 public immutable firstDrawStartsAt;
 
   /// @notice The exponential weighted average of all vault contributions.
@@ -240,12 +233,6 @@ contract PrizePool is TieredLiquidityDistributor {
 
   /// @notice The number of prize claims for the last closed draw.
   uint32 public claimCount;
-
-  /// @notice The number of canary prize claims for the last closed draw.
-  uint32 public canaryClaimCount;
-
-  /// @notice The largest tier claimed so far for the last closed draw.
-  uint8 public largestTierClaimed;
 
   /// @notice The timestamp at which the last closed draw started.
   uint64 internal _lastClosedDrawStartedAt;
@@ -263,7 +250,6 @@ contract PrizePool is TieredLiquidityDistributor {
     TieredLiquidityDistributor(
       params.numberOfTiers,
       params.tierShares,
-      params.canaryShares,
       params.reserveShares
     )
   {
@@ -273,7 +259,6 @@ contract PrizePool is TieredLiquidityDistributor {
     prizeToken = params.prizeToken;
     twabController = params.twabController;
     smoothing = params.smoothing;
-    claimExpansionThreshold = params.claimExpansionThreshold;
     drawPeriodSeconds = params.drawPeriodSeconds;
     _lastClosedDrawStartedAt = params.firstDrawStartsAt;
     firstDrawStartsAt = params.firstDrawStartsAt;
@@ -361,7 +346,7 @@ contract PrizePool is TieredLiquidityDistributor {
     uint8 _nextNumberOfTiers = _numTiers;
 
     if (lastClosedDrawId != 0) {
-      _nextNumberOfTiers = _computeNextNumberOfTiers(_numTiers);
+      _nextNumberOfTiers = _computeNextNumberOfTiers(claimCount);
     }
 
     uint64 openDrawStartedAt_ = _openDrawStartedAt();
@@ -370,8 +355,6 @@ contract PrizePool is TieredLiquidityDistributor {
 
     _winningRandomNumber = winningRandomNumber_;
     claimCount = 0;
-    canaryClaimCount = 0;
-    largestTierClaimed = 0;
     _lastClosedDrawStartedAt = openDrawStartedAt_;
     _lastClosedDrawAwardedAt = uint64(block.timestamp);
 
@@ -418,6 +401,7 @@ contract PrizePool is TieredLiquidityDistributor {
     Tier memory tierLiquidity = _getTier(_tier, numberOfTiers);
 
     if (_fee > tierLiquidity.prizeSize) {
+      console2.log("max fee: ", tierLiquidity.prizeSize);
       revert FeeTooLarge(_fee, tierLiquidity.prizeSize);
     }
 
@@ -440,15 +424,7 @@ contract PrizePool is TieredLiquidityDistributor {
 
     claimedPrizes[msg.sender][_winner][lastClosedDrawId][_tier][_prizeIndex] = true;
 
-    if (_isCanaryTier(_tier, numberOfTiers)) {
-      canaryClaimCount++;
-    } else {
-      claimCount++;
-    }
-
-    if (largestTierClaimed < _tier) {
-      largestTierClaimed = _tier;
-    }
+    claimCount++;
 
     // `amount` is a snapshot of the reserve before consuming liquidity
     _consumeLiquidity(tierLiquidity, _tier, tierLiquidity.prizeSize);
@@ -612,7 +588,7 @@ contract PrizePool is TieredLiquidityDistributor {
     uint8 _nextNumberOfTiers = _numTiers;
 
     if (lastClosedDrawId != 0) {
-      _nextNumberOfTiers = _computeNextNumberOfTiers(_numTiers);
+      _nextNumberOfTiers = _computeNextNumberOfTiers(claimCount);
     }
 
     (, uint104 newReserve, ) = _computeNewDistributions(
@@ -735,8 +711,8 @@ contract PrizePool is TieredLiquidityDistributor {
    * @notice Computes and returns the next number of tiers based on the current prize claim counts. This number may change throughout the draw
    * @return The next number of tiers
    */
-  function nextNumberOfTiers() external view returns (uint8) {
-    return _computeNextNumberOfTiers(numberOfTiers);
+  function estimateNextNumberOfTiers() external view returns (uint8) {
+    return _computeNextNumberOfTiers(claimCount);
   }
 
   /* ============ Internal Functions ============ */
@@ -779,37 +755,13 @@ contract PrizePool is TieredLiquidityDistributor {
   }
 
   /// @notice Calculates the number of tiers for the next draw
-  /// @param _numTiers The current number of tiers
   /// @return The number of tiers for the next draw
-  function _computeNextNumberOfTiers(uint8 _numTiers) internal view returns (uint8) {
-    UD2x18 _claimExpansionThreshold = claimExpansionThreshold;
+  function _computeNextNumberOfTiers(uint32 _claimCount) internal view returns (uint8) {
+    return _findHighestNumberOfTiersWithEstimatedPrizesLt(_claimCount*2);
+  }
 
-    uint8 _nextNumberOfTiers = largestTierClaimed + 2; // canary tier, then length
-    _nextNumberOfTiers = _nextNumberOfTiers > MINIMUM_NUMBER_OF_TIERS
-      ? _nextNumberOfTiers
-      : MINIMUM_NUMBER_OF_TIERS;
-
-    if (_nextNumberOfTiers >= MAXIMUM_NUMBER_OF_TIERS) {
-      return MAXIMUM_NUMBER_OF_TIERS;
-    }
-
-    // check to see if we need to expand the number of tiers
-    if (
-      _nextNumberOfTiers >= _numTiers &&
-      canaryClaimCount >=
-      convert(
-        intoUD60x18(_claimExpansionThreshold).mul(_canaryPrizeCountFractional(_numTiers).floor())
-      ) &&
-      claimCount >=
-      convert(
-        intoUD60x18(_claimExpansionThreshold).mul(convert(_estimatedPrizeCount(_numTiers)))
-      )
-    ) {
-      // increase the number of tiers to include a new tier
-      _nextNumberOfTiers = _numTiers + 1;
-    }
-
-    return _nextNumberOfTiers;
+  function computeNextNumberOfTiers(uint32 _claimCount) external view returns (uint8) {
+    return _computeNextNumberOfTiers(_claimCount);
   }
 
   /// @notice Computes the tokens to be disbursed from the accumulator for a given draw.
@@ -851,8 +803,7 @@ contract PrizePool is TieredLiquidityDistributor {
     SD59x18 _tierOdds,
     uint16 _drawDuration
   ) internal view returns (bool) {
-    uint8 _numberOfTiers = numberOfTiers;
-    uint32 tierPrizeCount = _getTierPrizeCount(_tier, _numberOfTiers);
+    uint32 tierPrizeCount = uint32(TierCalculationLib.prizeCount(_tier));
 
     if (_prizeIndex >= tierPrizeCount) {
       revert InvalidPrizeIndex(_prizeIndex, tierPrizeCount, _tier);

--- a/src/PrizePool.sol
+++ b/src/PrizePool.sol
@@ -755,8 +755,10 @@ contract PrizePool is TieredLiquidityDistributor {
     return _nextExpectedEndTime;
   }
 
-  /// @notice Calculates the number of tiers for the next draw
-  /// @return The number of tiers for the next draw
+  /// @notice Calculates the number of tiers given the number of prize claims
+  /// @dev This function will use the claim count to determine the number of tiers, then add one for the canary tier.
+  /// @param _claimCount The number of prize claims
+  /// @return The estimated number of tiers + the canary tier
   function _computeNextNumberOfTiers(uint32 _claimCount) internal pure returns (uint8) {
     // claimCount is expected to be the estimated number of claims for the current prize tier.
     // We add 1 to the claim count for the canary tier
@@ -764,6 +766,10 @@ contract PrizePool is TieredLiquidityDistributor {
     return numTiers > MAXIMUM_NUMBER_OF_TIERS ? MAXIMUM_NUMBER_OF_TIERS : numTiers; // add new canary tier
   }
 
+  /// @notice Calculates the number of tiers given the number of prize claims
+  /// @dev This function will use the claim count to determine the number of tiers, then add one for the canary tier.
+  /// @param _claimCount The number of prize claims
+  /// @return The estimated number of tiers + the canary tier
   function computeNextNumberOfTiers(uint32 _claimCount) external pure returns (uint8) {
     return _computeNextNumberOfTiers(_claimCount);
   }

--- a/src/PrizePool.sol
+++ b/src/PrizePool.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.19;
 
-import "forge-std/console2.sol";
-
 import { IERC20 } from "openzeppelin/token/ERC20/IERC20.sol";
 import { SafeERC20 } from "openzeppelin/token/ERC20/utils/SafeERC20.sol";
 import { E, SD59x18, sd } from "prb-math/SD59x18.sol";
@@ -401,7 +399,6 @@ contract PrizePool is TieredLiquidityDistributor {
     Tier memory tierLiquidity = _getTier(_tier, numberOfTiers);
 
     if (_fee > tierLiquidity.prizeSize) {
-      console2.log("max fee: ", tierLiquidity.prizeSize);
       revert FeeTooLarge(_fee, tierLiquidity.prizeSize);
     }
 

--- a/src/abstract/TieredLiquidityDistributor.sol
+++ b/src/abstract/TieredLiquidityDistributor.sol
@@ -2,8 +2,6 @@
 
 pragma solidity ^0.8.19;
 
-import "forge-std/console2.sol";
-
 import { E, SD59x18, sd } from "prb-math/SD59x18.sol";
 import { UD60x18, ud, convert, intoSD59x18 } from "prb-math/UD60x18.sol";
 import { UD2x18, intoUD60x18 } from "prb-math/UD2x18.sol";
@@ -321,19 +319,12 @@ contract TieredLiquidityDistributor {
       _currentPrizeTokenPerShare
     );
 
-    // console2.log("_computeNewDistributions reclaimedLiquidity", reclaimedLiquidity);
-    // console2.log("_computeNewDistributions _prizeTokenLiquidity", _prizeTokenLiquidity);
-
     uint totalNewLiquidity = _prizeTokenLiquidity + reclaimedLiquidity;
-    // console2.log("totalNewLiquidity", totalNewLiquidity);
     uint256 nextTotalShares = _getTotalShares(_nextNumberOfTiers);
     UD60x18 deltaPrizeTokensPerShare = (convert(totalNewLiquidity).div(convert(nextTotalShares))).floor();
     uint roundedNewLiquidity = convert(deltaPrizeTokensPerShare.mul(convert(nextTotalShares)));
-    // console2.log("roundedNewLiquidity", roundedNewLiquidity);
     uint newLiquidityRemainder = (totalNewLiquidity - roundedNewLiquidity);
-    // console2.log("newLiquidityRemainder", newLiquidityRemainder);
     
-
     newPrizeTokenPerShare = _currentPrizeTokenPerShare.add(deltaPrizeTokensPerShare);
 
     newReserve = uint104(

--- a/src/abstract/TieredLiquidityDistributor.sol
+++ b/src/abstract/TieredLiquidityDistributor.sol
@@ -65,6 +65,7 @@ contract TieredLiquidityDistributor {
   uint32 internal constant ESTIMATED_PRIZES_PER_DRAW_FOR_12_TIERS = 4912619;
   uint32 internal constant ESTIMATED_PRIZES_PER_DRAW_FOR_13_TIERS = 19805536;
   uint32 internal constant ESTIMATED_PRIZES_PER_DRAW_FOR_14_TIERS = 79777187;
+  uint32 internal constant ESTIMATED_PRIZES_PER_DRAW_FOR_15_TIERS = 321105952;
 
   /// @notice The odds for each tier and number of tiers pair.
   SD59x18 internal constant TIER_ODDS_0_3 = SD59x18.wrap(2739726027397260);
@@ -600,30 +601,32 @@ contract TieredLiquidityDistributor {
     return 0;
   }
 
-  function _findHighestNumberOfTiersWithEstimatedPrizesLt(uint32 _prizeCount) internal pure returns (uint8) {
+  function _estimateTierUsingPrizeCountPerDraw(uint32 _prizeCount) internal pure returns (uint8) {
     if (_prizeCount < ESTIMATED_PRIZES_PER_DRAW_FOR_3_TIERS) {
-      return 3;
+      return 2;
     } else if (_prizeCount < ESTIMATED_PRIZES_PER_DRAW_FOR_4_TIERS) {
-      return 4;
+      return 3;
     } else if (_prizeCount < ESTIMATED_PRIZES_PER_DRAW_FOR_5_TIERS) {
-      return 5;
+      return 4;
     } else if (_prizeCount < ESTIMATED_PRIZES_PER_DRAW_FOR_6_TIERS) {
-      return 6;
+      return 5;
     } else if (_prizeCount < ESTIMATED_PRIZES_PER_DRAW_FOR_7_TIERS) {
-      return 7;
+      return 6;
     } else if (_prizeCount < ESTIMATED_PRIZES_PER_DRAW_FOR_8_TIERS) {
-      return 8;
+      return 7;
     } else if (_prizeCount < ESTIMATED_PRIZES_PER_DRAW_FOR_9_TIERS) {
-      return 9;
+      return 8;
     } else if (_prizeCount < ESTIMATED_PRIZES_PER_DRAW_FOR_10_TIERS) {
-      return 10;
+      return 9;
     } else if (_prizeCount < ESTIMATED_PRIZES_PER_DRAW_FOR_11_TIERS) {
-      return 11;
+      return 10;
     } else if (_prizeCount < ESTIMATED_PRIZES_PER_DRAW_FOR_12_TIERS) {
-      return 12;
+      return 11;
     } else if (_prizeCount < ESTIMATED_PRIZES_PER_DRAW_FOR_13_TIERS) {
-      return 13;
+      return 12;
     } else if (_prizeCount < ESTIMATED_PRIZES_PER_DRAW_FOR_14_TIERS) {
+      return 13;
+    } else if (_prizeCount < ESTIMATED_PRIZES_PER_DRAW_FOR_15_TIERS) {
       return 14;
     }
     return 15;

--- a/src/abstract/TieredLiquidityDistributor.sol
+++ b/src/abstract/TieredLiquidityDistributor.sol
@@ -343,7 +343,7 @@ contract TieredLiquidityDistributor {
   /// @notice Returns the estimated number of prizes for the given tier.
   /// @param _tier The tier to retrieve
   /// @return The estimated number of prizes
-  function getTierPrizeCount(uint8 _tier) external view returns (uint32) {
+  function getTierPrizeCount(uint8 _tier) external pure returns (uint32) {
     return uint32(TierCalculationLib.prizeCount(_tier));
   }
 
@@ -600,7 +600,7 @@ contract TieredLiquidityDistributor {
     return 0;
   }
 
-  function _findHighestNumberOfTiersWithEstimatedPrizesLt(uint32 _prizeCount) internal view returns (uint8) {
+  function _findHighestNumberOfTiersWithEstimatedPrizesLt(uint32 _prizeCount) internal pure returns (uint8) {
     if (_prizeCount < ESTIMATED_PRIZES_PER_DRAW_FOR_3_TIERS) {
       return 3;
     } else if (_prizeCount < ESTIMATED_PRIZES_PER_DRAW_FOR_4_TIERS) {

--- a/src/abstract/TieredLiquidityDistributor.sol
+++ b/src/abstract/TieredLiquidityDistributor.sol
@@ -2,6 +2,8 @@
 
 pragma solidity ^0.8.19;
 
+import "forge-std/console2.sol";
+
 import { E, SD59x18, sd } from "prb-math/SD59x18.sol";
 import { UD60x18, ud, convert, intoSD59x18 } from "prb-math/UD60x18.sol";
 import { UD2x18, intoUD60x18 } from "prb-math/UD2x18.sol";
@@ -44,20 +46,6 @@ contract TieredLiquidityDistributor {
 
   uint8 internal constant MINIMUM_NUMBER_OF_TIERS = 3;
   uint8 internal constant MAXIMUM_NUMBER_OF_TIERS = 15;
-
-  UD60x18 internal immutable CANARY_PRIZE_COUNT_FOR_2_TIERS;
-  UD60x18 internal immutable CANARY_PRIZE_COUNT_FOR_3_TIERS;
-  UD60x18 internal immutable CANARY_PRIZE_COUNT_FOR_4_TIERS;
-  UD60x18 internal immutable CANARY_PRIZE_COUNT_FOR_5_TIERS;
-  UD60x18 internal immutable CANARY_PRIZE_COUNT_FOR_6_TIERS;
-  UD60x18 internal immutable CANARY_PRIZE_COUNT_FOR_7_TIERS;
-  UD60x18 internal immutable CANARY_PRIZE_COUNT_FOR_8_TIERS;
-  UD60x18 internal immutable CANARY_PRIZE_COUNT_FOR_9_TIERS;
-  UD60x18 internal immutable CANARY_PRIZE_COUNT_FOR_10_TIERS;
-  UD60x18 internal immutable CANARY_PRIZE_COUNT_FOR_11_TIERS;
-  UD60x18 internal immutable CANARY_PRIZE_COUNT_FOR_12_TIERS;
-  UD60x18 internal immutable CANARY_PRIZE_COUNT_FOR_13_TIERS;
-  UD60x18 internal immutable CANARY_PRIZE_COUNT_FOR_14_TIERS;
 
   //////////////////////// START GENERATED CONSTANTS ////////////////////////
   // The following constants are precomputed using the script/generateConstants.s.sol script.
@@ -207,9 +195,6 @@ contract TieredLiquidityDistributor {
   /// @notice The number of shares to allocate to each prize tier.
   uint8 public immutable tierShares;
 
-  /// @notice The number of shares to allocate to the canary tier.
-  uint8 public immutable canaryShares;
-
   /// @notice The number of shares to allocate to the reserve.
   uint8 public immutable reserveShares;
 
@@ -229,93 +214,12 @@ contract TieredLiquidityDistributor {
    * @notice Constructs a new Prize Pool.
    * @param _numberOfTiers The number of tiers to start with. Must be greater than or equal to the minimum number of tiers.
    * @param _tierShares The number of shares to allocate to each tier
-   * @param _canaryShares The number of shares to allocate to the canary tier.
    * @param _reserveShares The number of shares to allocate to the reserve.
    */
-  constructor(uint8 _numberOfTiers, uint8 _tierShares, uint8 _canaryShares, uint8 _reserveShares) {
+  constructor(uint8 _numberOfTiers, uint8 _tierShares, uint8 _reserveShares) {
     numberOfTiers = _numberOfTiers;
     tierShares = _tierShares;
-    canaryShares = _canaryShares;
     reserveShares = _reserveShares;
-
-    CANARY_PRIZE_COUNT_FOR_2_TIERS = TierCalculationLib.canaryPrizeCount(
-      2,
-      _canaryShares,
-      _reserveShares,
-      _tierShares
-    );
-    CANARY_PRIZE_COUNT_FOR_3_TIERS = TierCalculationLib.canaryPrizeCount(
-      3,
-      _canaryShares,
-      _reserveShares,
-      _tierShares
-    );
-    CANARY_PRIZE_COUNT_FOR_4_TIERS = TierCalculationLib.canaryPrizeCount(
-      4,
-      _canaryShares,
-      _reserveShares,
-      _tierShares
-    );
-    CANARY_PRIZE_COUNT_FOR_5_TIERS = TierCalculationLib.canaryPrizeCount(
-      5,
-      _canaryShares,
-      _reserveShares,
-      _tierShares
-    );
-    CANARY_PRIZE_COUNT_FOR_6_TIERS = TierCalculationLib.canaryPrizeCount(
-      6,
-      _canaryShares,
-      _reserveShares,
-      _tierShares
-    );
-    CANARY_PRIZE_COUNT_FOR_7_TIERS = TierCalculationLib.canaryPrizeCount(
-      7,
-      _canaryShares,
-      _reserveShares,
-      _tierShares
-    );
-    CANARY_PRIZE_COUNT_FOR_8_TIERS = TierCalculationLib.canaryPrizeCount(
-      8,
-      _canaryShares,
-      _reserveShares,
-      _tierShares
-    );
-    CANARY_PRIZE_COUNT_FOR_9_TIERS = TierCalculationLib.canaryPrizeCount(
-      9,
-      _canaryShares,
-      _reserveShares,
-      _tierShares
-    );
-    CANARY_PRIZE_COUNT_FOR_10_TIERS = TierCalculationLib.canaryPrizeCount(
-      10,
-      _canaryShares,
-      _reserveShares,
-      _tierShares
-    );
-    CANARY_PRIZE_COUNT_FOR_11_TIERS = TierCalculationLib.canaryPrizeCount(
-      11,
-      _canaryShares,
-      _reserveShares,
-      _tierShares
-    );
-    CANARY_PRIZE_COUNT_FOR_12_TIERS = TierCalculationLib.canaryPrizeCount(
-      12,
-      _canaryShares,
-      _reserveShares,
-      _tierShares
-    );
-    CANARY_PRIZE_COUNT_FOR_13_TIERS = TierCalculationLib.canaryPrizeCount(
-      13,
-      _canaryShares,
-      _reserveShares,
-      _tierShares
-    );
-    CANARY_PRIZE_COUNT_FOR_14_TIERS = TierCalculationLib.canaryPrizeCount(
-      14,
-      _canaryShares,
-      _reserveShares,
-      _tierShares
-    );
 
     if (_numberOfTiers < MINIMUM_NUMBER_OF_TIERS) {
       revert NumberOfTiersLessThanMinimum(_numberOfTiers);
@@ -410,24 +314,31 @@ contract TieredLiquidityDistributor {
     uint _prizeTokenLiquidity
   ) internal view returns (uint16 closedDrawId, uint104 newReserve, UD60x18 newPrizeTokenPerShare) {
     closedDrawId = lastClosedDrawId + 1;
-    uint256 totalShares = _getTotalShares(_nextNumberOfTiers);
-    UD60x18 deltaPrizeTokensPerShare = (convert(_prizeTokenLiquidity).div(convert(totalShares)))
-      .floor();
 
-    newPrizeTokenPerShare = _currentPrizeTokenPerShare.add(deltaPrizeTokensPerShare);
-
-    uint reclaimed = _getTierLiquidityToReclaim(
+    uint reclaimedLiquidity = _getTierLiquidityToReclaim(
       _numberOfTiers,
       _nextNumberOfTiers,
       _currentPrizeTokenPerShare
     );
-    uint computedLiquidity = convert(deltaPrizeTokensPerShare.mul(convert(totalShares)));
-    uint remainder = (_prizeTokenLiquidity - computedLiquidity);
+
+    // console2.log("_computeNewDistributions reclaimedLiquidity", reclaimedLiquidity);
+    // console2.log("_computeNewDistributions _prizeTokenLiquidity", _prizeTokenLiquidity);
+
+    uint totalNewLiquidity = _prizeTokenLiquidity + reclaimedLiquidity;
+    // console2.log("totalNewLiquidity", totalNewLiquidity);
+    uint256 nextTotalShares = _getTotalShares(_nextNumberOfTiers);
+    UD60x18 deltaPrizeTokensPerShare = (convert(totalNewLiquidity).div(convert(nextTotalShares))).floor();
+    uint roundedNewLiquidity = convert(deltaPrizeTokensPerShare.mul(convert(nextTotalShares)));
+    // console2.log("roundedNewLiquidity", roundedNewLiquidity);
+    uint newLiquidityRemainder = (totalNewLiquidity - roundedNewLiquidity);
+    // console2.log("newLiquidityRemainder", newLiquidityRemainder);
+    
+
+    newPrizeTokenPerShare = _currentPrizeTokenPerShare.add(deltaPrizeTokensPerShare);
 
     newReserve = uint104(
       convert(deltaPrizeTokensPerShare.mul(convert(reserveShares))) + // reserve portion
-        reclaimed + // reclaimed liquidity from tiers
-        remainder // remainder
+      newLiquidityRemainder // remainder
     );
   }
 
@@ -442,26 +353,7 @@ contract TieredLiquidityDistributor {
   /// @param _tier The tier to retrieve
   /// @return The estimated number of prizes
   function getTierPrizeCount(uint8 _tier) external view returns (uint32) {
-    return _getTierPrizeCount(_tier, numberOfTiers);
-  }
-
-  /// @notice Returns the estimated number of prizes for the given tier and number of tiers.
-  /// @param _tier The tier to retrieve
-  /// @param _numberOfTiers The number of tiers, should match the current number of tiers
-  /// @return The estimated number of prizes
-  function getTierPrizeCount(uint8 _tier, uint8 _numberOfTiers) external view returns (uint32) {
-    return _getTierPrizeCount(_tier, _numberOfTiers);
-  }
-
-  /// @notice Returns the number of available prizes for the given tier.
-  /// @param _tier The tier to retrieve
-  /// @param _numberOfTiers The number of tiers, should match the current number of tiers
-  /// @return The number of available prizes
-  function _getTierPrizeCount(uint8 _tier, uint8 _numberOfTiers) internal view returns (uint32) {
-    return
-      _isCanaryTier(_tier, _numberOfTiers)
-        ? _canaryPrizeCount(_numberOfTiers)
-        : uint32(TierCalculationLib.prizeCount(_tier));
+    return uint32(TierCalculationLib.prizeCount(_tier));
   }
 
   /// @notice Retrieves an up-to-date Tier struct for the given tier.
@@ -485,29 +377,20 @@ contract TieredLiquidityDistributor {
     return tier;
   }
 
-  /// @notice Computes the total shares in the system. That is `(number of tiers * tier shares) + canary shares + reserve shares`.
+  /// @notice Computes the total shares in the system. That is `(number of tiers * tier shares) + reserve shares`.
   /// @return The total shares
   function getTotalShares() external view returns (uint256) {
     return _getTotalShares(numberOfTiers);
   }
 
-  /// @notice Computes the total shares in the system given the number of tiers. That is `(number of tiers * tier shares) + canary shares + reserve shares`.
+  /// @notice Computes the total shares in the system given the number of tiers. That is `(number of tiers * tier shares) + reserve shares`.
   /// @param _numberOfTiers The number of tiers to calculate the total shares for
   /// @return The total shares
   function _getTotalShares(uint8 _numberOfTiers) internal view returns (uint256) {
     return
-      uint256(_numberOfTiers - 1) *
+      uint256(_numberOfTiers) *
       uint256(tierShares) +
-      uint256(canaryShares) +
       uint256(reserveShares);
-  }
-
-  /// @notice Computes the number of shares for the given tier. If the tier is the canary tier, then the canary shares are returned. Normal tier shares otherwise.
-  /// @param _tier The tier to request share for
-  /// @param _numTiers The number of tiers. Passed explicitly as an optimization
-  /// @return The number of shares for the given tier
-  function _computeShares(uint8 _tier, uint8 _numTiers) internal view returns (uint8) {
-    return _isCanaryTier(_tier, _numTiers) ? canaryShares : tierShares;
   }
 
   /// @notice Consumes liquidity from the given tier.
@@ -520,7 +403,7 @@ contract TieredLiquidityDistributor {
     uint8 _tier,
     uint104 _liquidity
   ) internal returns (Tier memory) {
-    uint8 _shares = _computeShares(_tier, numberOfTiers);
+    uint8 _shares = tierShares;
     uint104 remainingLiquidity = uint104(
       convert(
         _getTierRemainingLiquidity(
@@ -562,20 +445,15 @@ contract TieredLiquidityDistributor {
   ) internal view returns (uint256) {
     uint256 prizeSize;
     if (_prizeTokenPerShare.gt(_tierPrizeTokenPerShare)) {
+      prizeSize = _computePrizeSize(
+        _tierPrizeTokenPerShare,
+        _prizeTokenPerShare,
+        convert(TierCalculationLib.prizeCount(_tier)),
+        tierShares
+      );
       if (_isCanaryTier(_tier, _numberOfTiers)) {
-        prizeSize = _computePrizeSize(
-          _tierPrizeTokenPerShare,
-          _prizeTokenPerShare,
-          _canaryPrizeCountFractional(_numberOfTiers),
-          canaryShares
-        );
-      } else {
-        prizeSize = _computePrizeSize(
-          _tierPrizeTokenPerShare,
-          _prizeTokenPerShare,
-          convert(TierCalculationLib.prizeCount(_tier)),
-          tierShares
-        );
+        // make canary prizes smaller to account for reduction in shares for next number of tiers
+        prizeSize = (prizeSize * _getTotalShares(_numberOfTiers)) / _getTotalShares(_numberOfTiers + 1);
       }
     }
     return prizeSize;
@@ -618,7 +496,7 @@ contract TieredLiquidityDistributor {
     // need to redistribute to the canary tier and any new tiers (if expanding)
     uint8 start;
     uint8 end;
-    // if we are expanding, need to reset the canary tier and all of the new tiers
+    // if we are shrinking, we need to reclaim including the new canary tier
     if (_nextNumberOfTiers < _numberOfTiers) {
       start = _nextNumberOfTiers - 1;
       end = _numberOfTiers;
@@ -629,7 +507,7 @@ contract TieredLiquidityDistributor {
     }
     for (uint8 i = start; i < end; i++) {
       Tier memory tierLiquidity = _tiers[i];
-      uint8 shares = _computeShares(i, _numberOfTiers);
+      uint8 shares = tierShares;
       UD60x18 liq = _getTierRemainingLiquidity(
         shares,
         fromUD34x4toUD60x18(tierLiquidity.prizeTokenPerShare),
@@ -648,7 +526,7 @@ contract TieredLiquidityDistributor {
     return
       convert(
         _getTierRemainingLiquidity(
-          _computeShares(_tier, _numTiers),
+          tierShares,
           fromUD34x4toUD60x18(_getTier(_tier, _numTiers).prizeTokenPerShare),
           fromUD34x4toUD60x18(prizeTokenPerShare)
         )
@@ -691,33 +569,6 @@ contract TieredLiquidityDistributor {
     return _estimatedPrizeCount(numTiers);
   }
 
-  /// @notice Returns the number of canary prizes as a fraction. This allows the canary prize size to accurately represent the number of tiers + 1.
-  /// @param numTiers The number of prize tiers
-  /// @return The number of canary prizes
-  function canaryPrizeCountFractional(uint8 numTiers) external view returns (UD60x18) {
-    return _canaryPrizeCountFractional(numTiers);
-  }
-
-  /// @notice Computes the number of canary prizes for the last closed draw.
-  /// @return The number of canary prizes
-  function canaryPrizeCount() external view returns (uint32) {
-    return _canaryPrizeCount(numberOfTiers);
-  }
-
-  /// @notice Computes the number of canary prizes for the last closed draw
-  /// @param _numberOfTiers The number of tiers
-  /// @return The number of canary prizes
-  function _canaryPrizeCount(uint8 _numberOfTiers) internal view returns (uint32) {
-    return uint32(convert(_canaryPrizeCountFractional(_numberOfTiers).floor()));
-  }
-
-  /// @notice Computes the number of canary prizes given the number of tiers.
-  /// @param _numTiers The number of prize tiers
-  /// @return The number of canary prizes
-  function canaryPrizeCount(uint8 _numTiers) external view returns (uint32) {
-    return _canaryPrizeCount(_numTiers);
-  }
-
   /// @notice Returns the balance of the reserve.
   /// @return The amount of tokens that have been reserved.
   function reserve() external view returns (uint256) {
@@ -758,38 +609,33 @@ contract TieredLiquidityDistributor {
     return 0;
   }
 
-  /// @notice Computes the canary prize count for the given number of tiers
-  /// @param numTiers The number of prize tiers
-  /// @return The fractional canary prize count
-  function _canaryPrizeCountFractional(uint8 numTiers) internal view returns (UD60x18) {
-    if (numTiers == 3) {
-      return CANARY_PRIZE_COUNT_FOR_2_TIERS;
-    } else if (numTiers == 4) {
-      return CANARY_PRIZE_COUNT_FOR_3_TIERS;
-    } else if (numTiers == 5) {
-      return CANARY_PRIZE_COUNT_FOR_4_TIERS;
-    } else if (numTiers == 6) {
-      return CANARY_PRIZE_COUNT_FOR_5_TIERS;
-    } else if (numTiers == 7) {
-      return CANARY_PRIZE_COUNT_FOR_6_TIERS;
-    } else if (numTiers == 8) {
-      return CANARY_PRIZE_COUNT_FOR_7_TIERS;
-    } else if (numTiers == 9) {
-      return CANARY_PRIZE_COUNT_FOR_8_TIERS;
-    } else if (numTiers == 10) {
-      return CANARY_PRIZE_COUNT_FOR_9_TIERS;
-    } else if (numTiers == 11) {
-      return CANARY_PRIZE_COUNT_FOR_10_TIERS;
-    } else if (numTiers == 12) {
-      return CANARY_PRIZE_COUNT_FOR_11_TIERS;
-    } else if (numTiers == 13) {
-      return CANARY_PRIZE_COUNT_FOR_12_TIERS;
-    } else if (numTiers == 14) {
-      return CANARY_PRIZE_COUNT_FOR_13_TIERS;
-    } else if (numTiers == 15) {
-      return CANARY_PRIZE_COUNT_FOR_14_TIERS;
+  function _findHighestNumberOfTiersWithEstimatedPrizesLt(uint32 _prizeCount) internal view returns (uint8) {
+    if (_prizeCount < ESTIMATED_PRIZES_PER_DRAW_FOR_3_TIERS) {
+      return 3;
+    } else if (_prizeCount < ESTIMATED_PRIZES_PER_DRAW_FOR_4_TIERS) {
+      return 4;
+    } else if (_prizeCount < ESTIMATED_PRIZES_PER_DRAW_FOR_5_TIERS) {
+      return 5;
+    } else if (_prizeCount < ESTIMATED_PRIZES_PER_DRAW_FOR_6_TIERS) {
+      return 6;
+    } else if (_prizeCount < ESTIMATED_PRIZES_PER_DRAW_FOR_7_TIERS) {
+      return 7;
+    } else if (_prizeCount < ESTIMATED_PRIZES_PER_DRAW_FOR_8_TIERS) {
+      return 8;
+    } else if (_prizeCount < ESTIMATED_PRIZES_PER_DRAW_FOR_9_TIERS) {
+      return 9;
+    } else if (_prizeCount < ESTIMATED_PRIZES_PER_DRAW_FOR_10_TIERS) {
+      return 10;
+    } else if (_prizeCount < ESTIMATED_PRIZES_PER_DRAW_FOR_11_TIERS) {
+      return 11;
+    } else if (_prizeCount < ESTIMATED_PRIZES_PER_DRAW_FOR_12_TIERS) {
+      return 12;
+    } else if (_prizeCount < ESTIMATED_PRIZES_PER_DRAW_FOR_13_TIERS) {
+      return 13;
+    } else if (_prizeCount < ESTIMATED_PRIZES_PER_DRAW_FOR_14_TIERS) {
+      return 14;
     }
-    return ud(0);
+    return 15;
   }
 
   /// @notice Computes the odds for a tier given the number of tiers.

--- a/test/PrizePool.t.sol
+++ b/test/PrizePool.t.sol
@@ -576,6 +576,9 @@ contract PrizePoolTest is Test {
     prizePool = new PrizePool(prizePoolParams);
 
     contribute(510e18);
+
+    assertEq(prizePool.estimateNextNumberOfTiers(), 3, "will reduce to 3");
+
     closeDraw(1234);
 
     assertEq(prizePool.reserve(), 1e18, "reserve after first draw");

--- a/test/PrizePool.t.sol
+++ b/test/PrizePool.t.sol
@@ -614,8 +614,6 @@ contract PrizePoolTest is Test {
       claimPrize(sender2, 2, i);
     }
 
-    uint reserve = prizePool.reserve() + prizePool.reserveForOpenDraw();
-
     closeDraw(245);
     assertEq(prizePool.numberOfTiers(), 4);
   }

--- a/test/abstract/TieredLiquidityDistributor.t.sol
+++ b/test/abstract/TieredLiquidityDistributor.t.sol
@@ -58,16 +58,16 @@ contract TieredLiquidityDistributorTest is Test {
     );
   }
 
-  function testFindHighestNumberOfTiersWithEstimatedPrizesLt() public {
+  function testestimateTierUsingPrizeCountPerDraw() public {
     for (uint8 i = 2; i < 16; i++) {
       uint claimCount = TierCalculationLib.estimatedClaimCount(i, 365);
       assertEq(
-        distributor.findHighestNumberOfTiersWithEstimatedPrizesLt(uint32(claimCount)),
+        distributor.estimateTierUsingPrizeCountPerDraw(uint32(claimCount)),
         i,
         string.concat("tier", string(abi.encodePacked(i)))
       );
     }
-    assertEq(distributor.findHighestNumberOfTiersWithEstimatedPrizesLt(type(uint32).max), 15, "maximum");
+    assertEq(distributor.estimateTierUsingPrizeCountPerDraw(type(uint32).max), 15, "maximum");
   }
 
   function testRemainingTierLiquidity() public {

--- a/test/abstract/TieredLiquidityDistributor.t.sol
+++ b/test/abstract/TieredLiquidityDistributor.t.sol
@@ -59,9 +59,8 @@ contract TieredLiquidityDistributorTest is Test {
   }
 
   function testFindHighestNumberOfTiersWithEstimatedPrizesLt() public {
-    for (uint8 i = 3; i < 16; i++) {
-      // check i-1, because we don't count canary
-      uint claimCount = TierCalculationLib.estimatedClaimCount(i-1, 365);
+    for (uint8 i = 2; i < 16; i++) {
+      uint claimCount = TierCalculationLib.estimatedClaimCount(i, 365);
       assertEq(
         distributor.findHighestNumberOfTiersWithEstimatedPrizesLt(uint32(claimCount)),
         i,

--- a/test/abstract/TieredLiquidityDistributor.t.sol
+++ b/test/abstract/TieredLiquidityDistributor.t.sol
@@ -59,8 +59,15 @@ contract TieredLiquidityDistributorTest is Test {
   }
 
   function testFindHighestNumberOfTiersWithEstimatedPrizesLt() public {
-    assertEq(distributor.findHighestNumberOfTiersWithEstimatedPrizesLt(3), 3);
-    assertEq(distributor.findHighestNumberOfTiersWithEstimatedPrizesLt(15), 3, "top of tier 3");
+    for (uint8 i = 3; i < 16; i++) {
+      // check i-1, because we don't count canary
+      uint claimCount = TierCalculationLib.estimatedClaimCount(i-1, 365);
+      assertEq(
+        distributor.findHighestNumberOfTiersWithEstimatedPrizesLt(uint32(claimCount)),
+        i,
+        string.concat("tier", string(abi.encodePacked(i)))
+      );
+    }
     assertEq(distributor.findHighestNumberOfTiersWithEstimatedPrizesLt(type(uint32).max), 15, "maximum");
   }
 

--- a/test/abstract/helper/TieredLiquidityDistributorWrapper.sol
+++ b/test/abstract/helper/TieredLiquidityDistributorWrapper.sol
@@ -36,7 +36,7 @@ contract TieredLiquidityDistributorWrapper is TieredLiquidityDistributor {
       );
   }
 
-  function findHighestNumberOfTiersWithEstimatedPrizesLt(uint32 _prizeCount) external view returns (uint8) {
+  function estimateTierUsingPrizeCountPerDraw(uint32 _prizeCount) external pure returns (uint8) {
     uint8 result = _estimateTierUsingPrizeCountPerDraw(_prizeCount);
     return result;
   }

--- a/test/abstract/helper/TieredLiquidityDistributorWrapper.sol
+++ b/test/abstract/helper/TieredLiquidityDistributorWrapper.sol
@@ -9,9 +9,8 @@ contract TieredLiquidityDistributorWrapper is TieredLiquidityDistributor {
   constructor(
     uint8 _numberOfTiers,
     uint8 _tierShares,
-    uint8 _canaryShares,
     uint8 _reserveShares
-  ) TieredLiquidityDistributor(_numberOfTiers, _tierShares, _canaryShares, _reserveShares) {}
+  ) TieredLiquidityDistributor(_numberOfTiers, _tierShares, _reserveShares) {}
 
   function nextDraw(uint8 _nextNumTiers, uint96 liquidity) external {
     _nextDraw(_nextNumTiers, liquidity);
@@ -23,7 +22,7 @@ contract TieredLiquidityDistributorWrapper is TieredLiquidityDistributor {
   }
 
   function remainingTierLiquidity(uint8 _tier) external view returns (uint112) {
-    uint8 shares = _computeShares(_tier, numberOfTiers);
+    uint8 shares = tierShares;
     Tier memory tier = _getTier(_tier, numberOfTiers);
     return
       uint112(
@@ -35,6 +34,11 @@ contract TieredLiquidityDistributorWrapper is TieredLiquidityDistributor {
           )
         )
       );
+  }
+
+  function findHighestNumberOfTiersWithEstimatedPrizesLt(uint32 _prizeCount) external view returns (uint8) {
+    uint8 result = _findHighestNumberOfTiersWithEstimatedPrizesLt(_prizeCount);
+    return result;
   }
 
   function getTierLiquidityToReclaim(uint8 _nextNumberOfTiers) external view returns (uint256) {

--- a/test/abstract/helper/TieredLiquidityDistributorWrapper.sol
+++ b/test/abstract/helper/TieredLiquidityDistributorWrapper.sol
@@ -37,7 +37,7 @@ contract TieredLiquidityDistributorWrapper is TieredLiquidityDistributor {
   }
 
   function findHighestNumberOfTiersWithEstimatedPrizesLt(uint32 _prizeCount) external view returns (uint8) {
-    uint8 result = _findHighestNumberOfTiersWithEstimatedPrizesLt(_prizeCount);
+    uint8 result = _estimateTierUsingPrizeCountPerDraw(_prizeCount);
     return result;
   }
 

--- a/test/invariants/helpers/PrizePoolFuzzHarness.sol
+++ b/test/invariants/helpers/PrizePoolFuzzHarness.sol
@@ -25,9 +25,7 @@ contract PrizePoolFuzzHarness is CommonBase {
     uint64 nextDrawStartsAt = uint64(block.timestamp);
     uint8 numberOfTiers = 3;
     uint8 tierShares = 100;
-    uint8 canaryShares = 10;
     uint8 reserveShares = 10;
-    UD2x18 claimExpansionThreshold = UD2x18.wrap(0.9e18);
     SD1x18 smoothing = SD1x18.wrap(0.9e18);
 
     token = new ERC20Mintable("name", "SYMBOL");
@@ -43,9 +41,7 @@ contract PrizePoolFuzzHarness is CommonBase {
       nextDrawStartsAt,
       numberOfTiers,
       tierShares,
-      canaryShares,
       reserveShares,
-      claimExpansionThreshold,
       smoothing
     );
     prizePool = new PrizePool(params);

--- a/test/invariants/helpers/TieredLiquidityDistributorFuzzHarness.sol
+++ b/test/invariants/helpers/TieredLiquidityDistributorFuzzHarness.sol
@@ -14,7 +14,7 @@ contract TieredLiquidityDistributorFuzzHarness is TieredLiquidityDistributor {
   uint256 public totalAdded;
   uint256 public totalConsumed;
 
-  constructor() TieredLiquidityDistributor(3, 100, 10, 10) {}
+  constructor() TieredLiquidityDistributor(3, 100, 10) {}
 
   function nextDraw(uint8 _nextNumTiers, uint96 liquidity) external {
     uint8 nextNumTiers = _nextNumTiers / 16; // map to [0, 15]
@@ -34,7 +34,7 @@ contract TieredLiquidityDistributorFuzzHarness is TieredLiquidityDistributor {
       Tier memory tier = _getTier(i, numberOfTiers);
       availableLiquidity += convert(
         _getTierRemainingLiquidity(
-          _computeShares(i, numberOfTiers),
+          tierShares,
           fromUD34x4toUD60x18(tier.prizeTokenPerShare),
           fromUD34x4toUD60x18(prizeTokenPerShare)
         )
@@ -50,7 +50,7 @@ contract TieredLiquidityDistributorFuzzHarness is TieredLiquidityDistributor {
     uint8 tier = _tier % numberOfTiers;
 
     Tier memory tier_ = _getTier(tier, numberOfTiers);
-    uint8 shares = _computeShares(tier, numberOfTiers);
+    uint8 shares = tierShares;
     uint112 liq = uint112(
       convert(
         _getTierRemainingLiquidity(


### PR DESCRIPTION
The C4 issue pointed out that it's possible to maintain a high number of tiers by claiming the largest normal tier, even if the prize isn't worth claiming.

The solution fixes this by using the number of claimed prizes to determine the next prize tier. To simplify the algorithm further, the canary tier now has the same number of shares as a normal tier. This means that both "regular" and "canary" prizes are counted the same.

Instead of adjusting the number of canary prizes to ensure the prize size matches the expansion prize size, the algorithm adjusts the canary prize size directly.

Since the canary tier receives a significant amount of liquidity, reclaimed liquidity is distributed across all prizes instead of going into the reserve.
