### PR TITLE
Add dev message for binarySearch bounds

### DIFF
--- a/src/libraries/DrawAccumulatorLib.sol
+++ b/src/libraries/DrawAccumulatorLib.sol
@@ -409,7 +409,7 @@ library DrawAccumulatorLib {
   }
 
   /// @notice Binary searches an array of draw ids for the given target draw id.
-  /// @dev Index bounds and draw ID bounds must be checked in the implementation of this function.
+  /// @dev Index bounds and draw ID bounds must be validated before they are passed to this function.
   /// @param _drawRingBuffer The array of draw ids to search
   /// @param _oldestIndex The oldest index in the ring buffer
   /// @param _newestIndex The newest index in the ring buffer

--- a/src/libraries/DrawAccumulatorLib.sol
+++ b/src/libraries/DrawAccumulatorLib.sol
@@ -409,6 +409,7 @@ library DrawAccumulatorLib {
   }
 
   /// @notice Binary searches an array of draw ids for the given target draw id.
+  /// @dev Index bounds and draw ID bounds must be checked in the implementation of this function.
   /// @param _drawRingBuffer The array of draw ids to search
   /// @param _oldestIndex The oldest index in the ring buffer
   /// @param _newestIndex The newest index in the ring buffer

--- a/src/libraries/DrawAccumulatorLib.sol
+++ b/src/libraries/DrawAccumulatorLib.sol
@@ -409,7 +409,7 @@ library DrawAccumulatorLib {
   }
 
   /// @notice Binary searches an array of draw ids for the given target draw id.
-  /// @dev Index bounds and draw ID bounds must be validated before they are passed to this function.
+  /// @dev The _targetLastClosedDrawId MUST exist in the buffer between _oldestIndex and _newestIndex (inclusive)
   /// @param _drawRingBuffer The array of draw ids to search
   /// @param _oldestIndex The oldest index in the ring buffer
   /// @param _newestIndex The newest index in the ring buffer

--- a/test/libraries/DrawAccumulatorLib.t.sol
+++ b/test/libraries/DrawAccumulatorLib.t.sol
@@ -220,6 +220,18 @@ contract DrawAccumulatorLibTest is Test {
     assertEq(getDisbursedBetween(3, 4), 2538);
   }
 
+  function testGetDisbursedBetween_AfterLast() public {
+    add(1);
+    add(4);
+    // 1  1000
+    // 2  900
+    // 3  810
+    // 4  729 + 1000
+    // 5  656 + 900
+    // 6  590 + 810
+    assertEq(getDisbursedBetween(6, 6), 1400);
+  }
+
   function testIntegrateInf() public {
     assertEq(DrawAccumulatorLib.integrateInf(sd(0.9e18), 0, 100), 100);
     assertEq(DrawAccumulatorLib.integrateInf(sd(0.9e18), 1, 100), 90);


### PR DESCRIPTION
addresses c4-issue-445: https://github.com/code-423n4/2023-07-pooltogether-findings/issues/445

### Summary

When used in the intended context, the binarySearch function always has a valid exit condition. Instead of adding an additional, unreachable exit condition, the intended context has been added as a dev comment on the function.