### PR TITLE
revert claimPrize if fee recipient is zero address

### DIFF
--- a/src/PrizePool.sol
+++ b/src/PrizePool.sol
@@ -86,6 +86,9 @@ error CallerNotDrawManager(address caller, address drawManager);
 /// @notice Emitted when someone tries to claim a prize that is zero size
 error PrizeIsZero();
 
+/// @notice Emitted when someone tries to claim a prize, but sets the fee recipient address to the zero address.
+error FeeRecipientZeroAddress();
+
 /**
  * @notice Constructor Parameters
  * @param prizeToken The token to use for prizes
@@ -415,6 +418,10 @@ contract PrizePool is TieredLiquidityDistributor {
     uint96 _fee,
     address _feeRecipient
   ) external returns (uint256) {
+    if (_feeRecipient == address(0)) {
+      revert FeeRecipientZeroAddress();
+    }
+
     uint8 _numTiers = numberOfTiers;
 
     Tier memory tierLiquidity = _getTier(_tier, _numTiers);

--- a/src/PrizePool.sol
+++ b/src/PrizePool.sol
@@ -418,7 +418,7 @@ contract PrizePool is TieredLiquidityDistributor {
     uint96 _fee,
     address _feeRecipient
   ) external returns (uint256) {
-    if (_feeRecipient == address(0)) {
+    if (_feeRecipient == address(0) && _fee > 0) {
       revert FeeRecipientZeroAddress();
     }
 

--- a/test/PrizePool.t.sol
+++ b/test/PrizePool.t.sol
@@ -914,6 +914,14 @@ contract PrizePoolTest is Test {
     prizePool.claimPrize(sender1, 2, 0, sender1, 1, address(0));
   }
 
+  function testClaimPrize_ZeroAddressFeeRecipient_ZeroFee() public {
+    contribute(100e18);
+    closeDraw(winningRandomNumber);
+    mockTwab(address(this), sender1, 2);
+    prizePool.claimPrize(sender1, 2, 0, sender1, 0, address(0)); // zero fee, so no revert
+    assertEq(prizePool.claimCount(), 1);
+  }
+
   function testTotalWithdrawn() public {
     assertEq(prizePool.totalWithdrawn(), 0);
     contribute(100e18);

--- a/test/PrizePool.t.sol
+++ b/test/PrizePool.t.sol
@@ -31,6 +31,7 @@ import {
   DrawManagerAlreadySet,
   CallerNotDrawManager,
   NotDeployer,
+  FeeRecipientZeroAddress,
   MAXIMUM_NUMBER_OF_TIERS,
   MINIMUM_NUMBER_OF_TIERS
 } from "../src/PrizePool.sol";
@@ -799,7 +800,7 @@ contract PrizePoolTest is Test {
     mockTwab(address(this), winner, 1);
     assertEq(prizePool.getTierPrizeSize(2), 0, "prize size");
     vm.expectRevert(abi.encodeWithSelector(PrizeIsZero.selector));
-    prizePool.claimPrize(winner, 1, 0, winner, 0, address(0));
+    prizePool.claimPrize(winner, 1, 0, winner, 0, address(this));
   }
 
   function testClaimPrize_single() public {
@@ -822,9 +823,9 @@ contract PrizePoolTest is Test {
       0,
       uint152(prize),
       0,
-      address(0)
+      address(this)
     );
-    assertEq(prizePool.claimPrize(winner, 1, 0, recipient, 0, address(0)), prize);
+    assertEq(prizePool.claimPrize(winner, 1, 0, recipient, 0, address(this)), prize);
     assertEq(prizeToken.balanceOf(recipient), prize, "recipient balance is good");
     assertEq(prizePool.claimCount(), 1);
   }
@@ -859,7 +860,7 @@ contract PrizePoolTest is Test {
     mockTwab(address(this), msg.sender, 0);
     uint prize = prizePool.getTierPrizeSize(0);
     vm.expectRevert(abi.encodeWithSelector(FeeTooLarge.selector, 10e18, prize));
-    claimPrize(msg.sender, 0, 0, 10e18, address(0));
+    claimPrize(msg.sender, 0, 0, 10e18, address(this));
   }
 
   function testClaimPrize_grandPrize_cannotClaimTwice() public {
@@ -903,6 +904,14 @@ contract PrizePoolTest is Test {
     mockTwab(address(this), sender1, 2);
     claimPrize(sender1, 2, 0);
     assertEq(prizePool.claimCount(), 1);
+  }
+
+  function testClaimPrize_ZeroAddressFeeRecipient() public {
+    contribute(100e18);
+    closeDraw(winningRandomNumber);
+    mockTwab(address(this), sender1, 2);
+    vm.expectRevert(abi.encodeWithSelector(FeeRecipientZeroAddress.selector));
+    prizePool.claimPrize(sender1, 2, 0, sender1, 1, address(0));
   }
 
   function testTotalWithdrawn() public {
@@ -1148,7 +1157,7 @@ contract PrizePoolTest is Test {
   }
 
   function claimPrize(address sender, uint8 tier, uint32 prizeIndex) public returns (uint256) {
-    return claimPrize(sender, tier, prizeIndex, 0, address(0));
+    return claimPrize(sender, tier, prizeIndex, 0, address(this));
   }
 
   function claimPrize(


### PR DESCRIPTION
addresses c4-issue-219: https://github.com/code-423n4/2023-07-pooltogether-findings/issues/219

### Summary
Added a conditional revert if the fee recipient is set to the zero address. 