### PR TITLE
uint => uint256

### DIFF
--- a/src/abstract/TieredLiquidityDistributor.sol
+++ b/src/abstract/TieredLiquidityDistributor.sol
@@ -296,17 +296,17 @@ contract TieredLiquidityDistributor {
     uint8 _numberOfTiers,
     uint8 _nextNumberOfTiers,
     UD60x18 _currentPrizeTokenPerShare,
-    uint _prizeTokenLiquidity
+    uint256 _prizeTokenLiquidity
   ) internal view returns (uint24 closedDrawId, uint96 newReserve, UD60x18 newPrizeTokenPerShare) {
     closedDrawId = lastClosedDrawId + 1;
 
-    uint reclaimedLiquidity = _getTierLiquidityToReclaim(
+    uint256 reclaimedLiquidity = _getTierLiquidityToReclaim(
       _numberOfTiers,
       _nextNumberOfTiers,
       _currentPrizeTokenPerShare
     );
 
-    uint totalNewLiquidity = _prizeTokenLiquidity + reclaimedLiquidity;
+    uint256 totalNewLiquidity = _prizeTokenLiquidity + reclaimedLiquidity;
     uint256 nextTotalShares = _getTotalShares(_nextNumberOfTiers);
     UD60x18 deltaPrizeTokensPerShare = (convert(totalNewLiquidity).div(convert(nextTotalShares))).floor();
     

--- a/src/libraries/DrawAccumulatorLib.sol
+++ b/src/libraries/DrawAccumulatorLib.sol
@@ -278,7 +278,7 @@ library DrawAccumulatorLib {
       uint24 headStartDrawId = _startDrawId - observationDrawIdBeforeOrAtStart;
       uint24 headEndDrawId = headStartDrawId +
         (firstObservationDrawIdOccurringAtOrAfterStart - _startDrawId);
-      uint amount = integrate(_alpha, headStartDrawId, headEndDrawId, beforeOrAtStart.available);
+      uint256 amount = integrate(_alpha, headStartDrawId, headEndDrawId, beforeOrAtStart.available);
       total += amount;
     }
 
@@ -292,7 +292,7 @@ library DrawAccumulatorLib {
         firstObservationDrawIdOccurringAtOrAfterStart
       ];
       atOrBeforeEnd = _accumulator.observations[lastObservationDrawIdOccurringAtOrBeforeEnd];
-      uint amount = atOrBeforeEnd.disbursed - atOrAfterStart.disbursed;
+      uint256 amount = atOrBeforeEnd.disbursed - atOrAfterStart.disbursed;
       total += amount;
     }
 
@@ -378,7 +378,7 @@ library DrawAccumulatorLib {
   /// @param _x The x value to integrate from.
   /// @param _k The k value to scale the sum (this is the total available balance).
   /// @return The integration from x to inf of the EWA for the given parameters.
-  function integrateInf(SD59x18 _alpha, uint _x, uint _k) internal pure returns (uint256) {
+  function integrateInf(SD59x18 _alpha, uint256 _x, uint256 _k) internal pure returns (uint256) {
     return uint256(convert(computeC(_alpha, _x, _k)));
   }
 
@@ -390,9 +390,9 @@ library DrawAccumulatorLib {
   /// @return The integration from start to end of the EWA for the given parameters.
   function integrate(
     SD59x18 _alpha,
-    uint _start,
-    uint _end,
-    uint _k
+    uint256 _start,
+    uint256 _end,
+    uint256 _k
   ) internal pure returns (uint256) {
     int start = unwrap(computeC(_alpha, _start, _k));
     int end = unwrap(computeC(_alpha, _end, _k));
@@ -404,7 +404,7 @@ library DrawAccumulatorLib {
   /// @param _x The x value to compute for
   /// @param _k The total available balance
   /// @return The value C
-  function computeC(SD59x18 _alpha, uint _x, uint _k) internal pure returns (SD59x18) {
+  function computeC(SD59x18 _alpha, uint256 _x, uint256 _k) internal pure returns (SD59x18) {
     return convert(int(_k)).mul(_alpha.pow(convert(int256(_x))));
   }
 


### PR DESCRIPTION
Change `uint` to `uint256` for consistency in contracts.

Fixes [06] on C4-422: https://github.com/code-423n4/2023-07-pooltogether-findings/blob/main/data/catellatech-Q.md#06-in-the-contract-tieredliquiditydistributor_computenewdistributions-use-uint256-instead-uint