### PR TITLE
Type consistency & more gas optimizations

### DIFF
--- a/src/libraries/TierCalculationLib.sol
+++ b/src/libraries/TierCalculationLib.sol
@@ -81,7 +81,7 @@ library TierCalculationLib {
   /// @param _winningRandomNumber The winning random number
   /// @return A pseudo-random number
   function calculatePseudoRandomNumber(
-    uint32 _drawId,
+    uint24 _drawId,
     address _vault,
     address _user,
     uint8 _tier,

--- a/test/PrizePool.t.sol
+++ b/test/PrizePool.t.sol
@@ -1238,10 +1238,7 @@ contract PrizePoolTest is Test {
   }
 
   function claimPrize(address sender, uint8 tier, uint32 prizeIndex) public returns (uint256) {
-    uint256 gas = gasleft();
-    uint256 res = claimPrize(sender, tier, prizeIndex, 0, address(this));
-    console2.log("claimPrize gas: ", gas - gasleft());
-    return res;
+    return claimPrize(sender, tier, prizeIndex, 0, address(this));
   }
 
   function claimPrize(

--- a/test/invariants/helpers/DrawAccumulatorFuzzHarness.sol
+++ b/test/invariants/helpers/DrawAccumulatorFuzzHarness.sol
@@ -15,7 +15,7 @@ contract DrawAccumulatorFuzzHarness {
 
   uint16 currentDrawId = 1;
 
-  function add(uint64 _amount, uint8 _drawInc) public returns (bool) {
+  function add(uint88 _amount, uint8 _drawInc) public returns (bool) {
     currentDrawId += (_drawInc / 16);
     SD59x18 alpha = sd(0.9e18);
     bool result = accumulator.add(_amount, currentDrawId, alpha);

--- a/test/invariants/helpers/PrizePoolFuzzHarness.sol
+++ b/test/invariants/helpers/PrizePoolFuzzHarness.sol
@@ -31,7 +31,7 @@ contract PrizePoolFuzzHarness is CommonBase, StdCheats {
     address drawManager = address(this);
     uint32 drawPeriodSeconds = 1 hours;
     currentTime = block.timestamp;
-    uint64 nextDrawStartsAt = uint64(currentTime);
+    uint48 nextDrawStartsAt = uint48(currentTime);
     uint8 numberOfTiers = 3;
     uint8 tierShares = 100;
     uint8 reserveShares = 10;
@@ -57,13 +57,13 @@ contract PrizePoolFuzzHarness is CommonBase, StdCheats {
     prizePool.setDrawManager(drawManager);
   }
 
-  function contributePrizeTokens(uint64 _amount) public warp {
+  function contributePrizeTokens(uint88 _amount) public warp {
     contributed += _amount;
     token.mint(address(prizePool), _amount);
     prizePool.contributePrizeTokens(address(this), _amount);
   }
 
-  function contributeReserve(uint64 _amount) public warp {
+  function contributeReserve(uint88 _amount) public warp {
     contributed += _amount;
     token.mint(address(this), _amount);
     token.approve(address(prizePool), _amount);


### PR DESCRIPTION
- sync drawId to uint24
- sync timestamps to uint48
- also bumped fuzz prize amounts to uint88 since max uint64 is only 18.4 prize tokens (not a very realistic test of extremes)