### PR TITLE
remove calculateTierTwabTimestamps

### DIFF
--- a/src/PrizePool.sol
+++ b/src/PrizePool.sol
@@ -730,25 +730,6 @@ contract PrizePool is TieredLiquidityDistributor, Ownable {
       );
   }
 
-  /***
-   * @notice Calculates the start and end timestamps of the time-weighted average balance (TWAB) for the specified tier.
-   * @param _tier The tier for which to calculate the TWAB timestamps.
-   * @return The start and end timestamps of the TWAB.
-   */
-  function calculateTierTwabTimestamps(
-    uint8 _tier
-  ) external view returns (uint48 startTimestamp, uint48 endTimestamp) {
-    uint8 _numberOfTiers = numberOfTiers;
-    _checkValidTier(_tier, _numberOfTiers);
-
-    endTimestamp = _drawClosesAt(_lastAwardedDrawId);
-    startTimestamp = uint48(
-      endTimestamp -
-        TierCalculationLib.estimatePrizeFrequencyInDraws(_tierOdds(_tier, _numberOfTiers)) *
-        drawPeriodSeconds
-    );
-  }
-
   /**
    * @notice Returns the time-weighted average balance (TWAB) and the TWAB total supply for the specified user in the given vault over a specified period.
    * @param _vault The address of the vault for which to get the TWAB.

--- a/test/PrizePool.t.sol
+++ b/test/PrizePool.t.sol
@@ -1438,7 +1438,10 @@ contract PrizePoolTest is Test {
   }
 
   function mockTwab(address _vault, address _account, uint8 _tier) public {
-    (uint48 startTime, uint48 endTime) = prizePool.calculateTierTwabTimestamps(_tier);
+    uint48 endTime = prizePool.drawClosesAt(prizePool.getLastAwardedDrawId());
+    uint48 startTime = uint48(
+      endTime - prizePool.getTierAccrualDurationInDraws(_tier) * drawPeriodSeconds
+    );
     mockTwab(_vault, _account, startTime, endTime);
   }
 }


### PR DESCRIPTION
Function was unused (except in unit tests) and can be replicated by a few extra external calls.