### PR TITLE
Gen 1082 add emergency shutdown mode to the prize pool

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -8,7 +8,7 @@ gas_limit = "18446744073709551615" # u64::MAX
 block_gas_limit = "18446744073709551615" # u64::MAX
 fs_permissions = [{ access = "read-write", path = "./data"}]
 optimizer = true
-via_ir = false
+via_ir = true
 ffi = true
 
 [profile.default.optimizer_details]

--- a/foundry.toml
+++ b/foundry.toml
@@ -3,8 +3,8 @@ src = 'src'
 out = 'out'
 libs = ['lib']
 solc = "0.8.19"
-gas_limit = "18446744073709551615" # u64::MAX
 gas_reports_ignore = ["ERC20Mintable", "TwabController"]
+gas_limit = "18446744073709551615" # u64::MAX
 block_gas_limit = "18446744073709551615" # u64::MAX
 fs_permissions = [{ access = "read-write", path = "./data"}]
 optimizer = true
@@ -22,8 +22,12 @@ constant_optimizer = true
 yul = true
 
 [invariant]
-fail_on_revert = true
-    
+runs = 4
+depth = 400
+
+[fuzz]
+seed = "0x0ca1b799da18587180cdb11fc96564bf73af56a3f4e6981971452fc78cb0dcbc"
+
 [rpc_endpoints]
 mainnet = "${MAINNET_RPC_URL}"
 arbitrum = "${ARBITRUM_RPC_URL}"

--- a/src/PrizePool.sol
+++ b/src/PrizePool.sol
@@ -607,7 +607,7 @@ contract PrizePool is TieredLiquidityDistributor, Ownable {
   /// @return The number of draws
   function getTierAccrualDurationInDraws(uint8 _tier) external view returns (uint24) {
     return
-      uint24(TierCalculationLib.estimatePrizeFrequencyInDraws(_tierOdds(_tier, numberOfTiers)));
+      uint24(TierCalculationLib.estimatePrizeFrequencyInDraws(getTierOdds(_tier, numberOfTiers)));
   }
 
   /// @notice The total amount of prize tokens that have been withdrawn as fees or prizes
@@ -1003,7 +1003,7 @@ contract PrizePool is TieredLiquidityDistributor, Ownable {
     }
     _checkValidTier(_tier, _numberOfTiers);
 
-    tierOdds = _tierOdds(_tier, _numberOfTiers);
+    tierOdds = getTierOdds(_tier, _numberOfTiers);
     startDrawIdInclusive = computeRangeStartDrawIdInclusive(lastAwardedDrawId_, uint24(TierCalculationLib.estimatePrizeFrequencyInDraws(tierOdds)));
     vaultPortion = getVaultPortion(
       _vault,

--- a/src/PrizePool.sol
+++ b/src/PrizePool.sol
@@ -5,7 +5,7 @@ import { SafeCast } from "openzeppelin/utils/math/SafeCast.sol";
 import { Ownable } from "openzeppelin/access/Ownable.sol";
 import { IERC20 } from "openzeppelin/token/ERC20/IERC20.sol";
 import { SafeERC20 } from "openzeppelin/token/ERC20/utils/SafeERC20.sol";
-import { SD59x18, sd } from "prb-math/SD59x18.sol";
+import { SD59x18, convert, sd } from "prb-math/SD59x18.sol";
 import { SD1x18, unwrap, UNIT } from "prb-math/SD1x18.sol";
 import { TwabController } from "pt-v5-twab-controller/TwabController.sol";
 
@@ -28,6 +28,12 @@ error DrawManagerIsZeroAddress();
 
 /// @notice Emitted when the caller is not the deployer.
 error NotDeployer();
+
+/// @notice Emitted if the prize pool has shutdown
+error PrizePoolShutdown();
+
+/// @notice Emitted if the prize pool is not shutdown
+error PrizePoolNotShutdown();
 
 /// @notice Emitted when someone tries to withdraw too many rewards.
 /// @param requested The requested reward amount to withdraw
@@ -217,6 +223,9 @@ contract PrizePool is TieredLiquidityDistributor, Ownable {
   /// @notice Tracks the total rewards accrued for a claimer or draw completer.
   mapping(address recipient => uint256 rewards) internal _rewards;
 
+  /// @notice Records the last shutdown withdrawal for an account
+  mapping(address vault => mapping(address user => uint24 drawId)) internal _lastShutdownWithdrawal;
+
   /// @notice The degree of POOL contribution smoothing. 0 = no smoothing, ~1 = max smoothing.
   /// @dev Smoothing spreads out vault contribution over multiple draws; the higher the smoothing the more draws.
   SD1x18 public immutable smoothing;
@@ -236,23 +245,26 @@ contract PrizePool is TieredLiquidityDistributor, Ownable {
   /// @notice The maximum number of draws that can be missed before the prize pool is considered inactive.
   uint32 public immutable maxMissedDraws;
 
-  /// @notice The draw manager address.
-  address public drawManager;
-
   /// @notice The exponential weighted average of all vault contributions.
   DrawAccumulatorLib.Accumulator internal _totalAccumulator;
 
   /// @notice The winner random number for the last awarded draw.
   uint256 internal _winningRandomNumber;
 
+  /// @notice The draw manager address.
+  address public drawManager;
+
+  /// @notice Tracks reserve that was contributed directly to the reserve. Always increases.
+  uint96 internal _directlyContributedReserve;
+
   /// @notice The number of prize claims for the last awarded draw.
-  uint32 public claimCount;
+  uint24 public claimCount;
 
   /// @notice The total amount of prize tokens that have been claimed for all time.
   uint128 internal _totalWithdrawn;
 
-  /// @notice Tracks reserve that was contributed directly to the reserve. Always increases.
-  uint96 internal _directlyContributedReserve;
+  /// @notice The total amount of rewards that have yet to be claimed
+  uint104 internal _totalRewardsToBeClaimed;
 
   /* ============ Constructor ============ */
 
@@ -354,6 +366,7 @@ contract PrizePool is TieredLiquidityDistributor, Ownable {
     }
 
     _rewards[_to] += _amount;
+    _totalRewardsToBeClaimed = SafeCast.toUint104(_totalRewardsToBeClaimed + _amount);
     emit AllocateRewardFromReserve(_to, _amount);
   }
 
@@ -361,7 +374,7 @@ contract PrizePool is TieredLiquidityDistributor, Ownable {
   /// @dev Updates the number of tiers, the winning random number and the prize pool reserve.
   /// @param winningRandomNumber_ The winning random number for the draw
   /// @return The ID of the awarded draw
-  function awardDraw(uint256 winningRandomNumber_) external onlyDrawManager returns (uint24) {
+  function awardDraw(uint256 winningRandomNumber_) external onlyDrawManager notShutdown returns (uint24) {
     // check winning random number
     if (winningRandomNumber_ == 0) {
       revert RandomNumberIsZero();
@@ -379,7 +392,7 @@ contract PrizePool is TieredLiquidityDistributor, Ownable {
     uint8 _nextNumberOfTiers = _numTiers;
 
     if (lastAwardedDrawId_ != 0) {
-      _nextNumberOfTiers = _computeNextNumberOfTiers(_claimCount);
+      _nextNumberOfTiers = computeNextNumberOfTiers(_claimCount);
     }
 
     /**
@@ -436,7 +449,7 @@ contract PrizePool is TieredLiquidityDistributor, Ownable {
     address _prizeRecipient,
     uint96 _claimReward,
     address _claimRewardRecipient
-  ) external returns (uint256) {
+  ) external notShutdown returns (uint256) {
     /**
      * @dev Claims cannot occur after a draw has been finalized (1 period after a draw closes). This prevents
      * the reserve from changing while the following draw is being awarded.
@@ -461,28 +474,8 @@ contract PrizePool is TieredLiquidityDistributor, Ownable {
       revert PrizeIsZero();
     }
 
-    {
-      // hide the variables!
-      (
-        SD59x18 _vaultPortion,
-        SD59x18 _computedTierOdds,
-        uint24 _drawDuration
-      ) = _computeVaultTierDetails(msg.sender, _tier, _numTiers, lastAwardedDrawId_);
-
-      if (
-        !_isWinner(
-          lastAwardedDrawId_,
-          msg.sender,
-          _winner,
-          _tier,
-          _prizeIndex,
-          _vaultPortion,
-          _computedTierOdds,
-          _drawDuration
-        )
-      ) {
-        revert DidNotWin(msg.sender, _winner, _tier, _prizeIndex);
-      }
+    if (!isWinner(msg.sender, _winner, _tier, _prizeIndex)) {
+      revert DidNotWin(msg.sender, _winner, _tier, _prizeIndex);
     }
 
     if (_claimedPrizes[msg.sender][_winner][lastAwardedDrawId_][_tier][_prizeIndex]) {
@@ -510,6 +503,7 @@ contract PrizePool is TieredLiquidityDistributor, Ownable {
     // co-locate to save gas
     claimCount++;
     _totalWithdrawn = SafeCast.toUint128(_totalWithdrawn + amount);
+    _totalRewardsToBeClaimed = SafeCast.toUint104(_totalRewardsToBeClaimed + _claimReward);
 
     emit ClaimedPrize(
       msg.sender,
@@ -544,7 +538,11 @@ contract PrizePool is TieredLiquidityDistributor, Ownable {
       _rewards[msg.sender] = _available - _amount;
     }
 
-    _transfer(_to, _amount);
+    _totalWithdrawn = SafeCast.toUint128(_totalWithdrawn + _amount);
+    _totalRewardsToBeClaimed = SafeCast.toUint104(_totalRewardsToBeClaimed - _amount);
+
+    prizeToken.safeTransfer(_to, _amount);
+
     emit WithdrawRewards(msg.sender, _to, _amount, _available);
   }
 
@@ -669,7 +667,7 @@ contract PrizePool is TieredLiquidityDistributor, Ownable {
 
     (uint104 newReserve, ) = _computeNewDistributions(
       _numTiers,
-      lastAwardedDrawId_ == 0 ? _numTiers : _computeNextNumberOfTiers(claimCount),
+      lastAwardedDrawId_ == 0 ? _numTiers : computeNextNumberOfTiers(claimCount),
       fromUD34x4toUD60x18(prizeTokenPerShare),
       _getTotalContributedBetween(lastAwardedDrawId_ + 1, _drawIdToAward())
     );
@@ -714,9 +712,9 @@ contract PrizePool is TieredLiquidityDistributor, Ownable {
     address _user,
     uint8 _tier,
     uint32 _prizeIndex
-  ) external view returns (bool) {
+  ) public view returns (bool) {
     uint24 lastAwardedDrawId_ = _lastAwardedDrawId;
-    (SD59x18 vaultPortion, SD59x18 tierOdds, uint24 drawDuration) = _computeVaultTierDetails(
+    (SD59x18 vaultPortion, SD59x18 tierOdds, uint24 startDrawIdInclusive) = _computeVaultTierDetails(
       _vault,
       _tier,
       numberOfTiers,
@@ -731,38 +729,8 @@ contract PrizePool is TieredLiquidityDistributor, Ownable {
         _prizeIndex,
         vaultPortion,
         tierOdds,
-        drawDuration
+        startDrawIdInclusive
       );
-  }
-
-  /**
-   * @notice Returns the time-weighted average balance (TWAB) and the TWAB total supply for the specified user in the given vault over a specified period.
-   * @param _vault The address of the vault for which to get the TWAB.
-   * @param _user The address of the user for which to get the TWAB.
-   * @param _drawDuration The duration of the period over which to calculate the TWAB, in number of draw periods.
-   * @return The TWAB and the TWAB total supply for the specified user in the given vault over the specified period.
-   */
-  function getVaultUserBalanceAndTotalSupplyTwab(
-    address _vault,
-    address _user,
-    uint256 _drawDuration
-  ) external view returns (uint256, uint256) {
-    return _getVaultUserBalanceAndTotalSupplyTwab(_vault, _user, _drawDuration);
-  }
-
-  /**
-   * @notice Returns the portion of a vault's contributions in a given draw range as a fraction.
-   * @param _vault The address of the vault to calculate the contribution portion for.
-   * @param _startDrawId The starting draw ID of the draw range to calculate the contribution portion for.
-   * @param _endDrawId The ending draw ID of the draw range to calculate the contribution portion for.
-   * @return The portion of the _vault's contributions in the given draw range as an SD59x18 value.
-   */
-  function getVaultPortion(
-    address _vault,
-    uint24 _startDrawId,
-    uint24 _endDrawId
-  ) external view returns (SD59x18) {
-    return _getVaultPortion(_vault, _startDrawId, _endDrawId);
   }
 
   /**
@@ -770,7 +738,7 @@ contract PrizePool is TieredLiquidityDistributor, Ownable {
    * @return The next number of tiers
    */
   function estimateNextNumberOfTiers() external view returns (uint8) {
-    return _computeNextNumberOfTiers(claimCount);
+    return computeNextNumberOfTiers(claimCount);
   }
 
   /* ============ Internal Functions ============ */
@@ -781,6 +749,19 @@ contract PrizePool is TieredLiquidityDistributor, Ownable {
     Observation memory obs = _totalAccumulator.observations[
       DrawAccumulatorLib.newestDrawId(_totalAccumulator)
     ];
+    // totalRewards would be added to the below accounted balance.
+    // obs.disbursed include the reserve, prizes, and prize liquidity
+
+    /*
+       obs.disbursed is the total amount of tokens all-time contributed by vaults and released. These tokens may:
+       - still be held for future prizes
+       - have been given as prizes
+       - have been captured as fees
+    */
+    // obs.available is the total number of tokens that WILL be disbursed in the future.
+    // _directlyContributedReserve are tokens that have been contributed directly to the reserve
+    // totalWithdrawn represents all tokens that have been withdrawn
+
     return (obs.available + obs.disbursed) + uint256(_directlyContributedReserve) - uint256(_totalWithdrawn);
   }
 
@@ -841,7 +822,7 @@ contract PrizePool is TieredLiquidityDistributor, Ownable {
   /// @dev This function will use the claim count to determine the number of tiers, then add one for the canary tier.
   /// @param _claimCount The number of prize claims
   /// @return The estimated number of tiers + the canary tier
-  function _computeNextNumberOfTiers(uint32 _claimCount) internal view returns (uint8) {
+  function computeNextNumberOfTiers(uint32 _claimCount) public view returns (uint8) {
     // claimCount is expected to be the estimated number of claims for the current prize tier.
     uint8 nextNumberOfTiers = _estimateNumberOfTiersUsingPrizeCountPerDraw(_claimCount) + 1;
     // limit change to 1 tier
@@ -854,12 +835,82 @@ contract PrizePool is TieredLiquidityDistributor, Ownable {
     return nextNumberOfTiers;
   }
 
-  /// @notice Calculates the number of tiers given the number of prize claims
-  /// @dev This function will use the claim count to determine the number of tiers, then add one for the canary tier.
-  /// @param _claimCount The number of prize claims
-  /// @return The estimated number of tiers + the canary tier
-  function computeNextNumberOfTiers(uint32 _claimCount) external view returns (uint8) {
-    return _computeNextNumberOfTiers(_claimCount);
+/*
+  function shutdownBalanceOf(address _vault, address _account) external view returns (uint256) {
+    uint24 lastWithdrawalDrawId = _lastShutdownWithdrawal[_vault][_account];
+
+    uint256 balance;
+
+    // if they have not withdrawn yet, then add the balance prior to the last awarded draw.
+    if (lastWithdrawalDrawId == 0) {
+
+      // compute the range, and the vaults portion
+      uint24 startDrawId = computeRangeStartDrawIdInclusive(_lastAwardedDrawId, grandPrizePeriodDraws);
+      // compute the liquidity available, less whatever is after the range
+      uint256 afterRange = _getTotalContributedBetween(_lastAwardedDrawId + 1, _drawIdToAward()) + DrawAccumulatorLib.getTotalRemaining(_totalAccumulator, _drawIdToAward()+1, smoothing.intoSD59x18());
+      uint256 totalAvailable = prizeToken.balanceOf(address(this)) - _totalRewardsToBeClaimed - afterRange;
+      balance += _computeShutdownBalanceInRange(_vault, _account, totalAvailable, startDrawId);
+
+      lastWithdrawalDrawId = _lastAwardedDrawId;
+    }
+
+    uint24 endDrawId = _drawIdToAward();
+    if (lastWithdrawalDrawId < endDrawId) {
+      uint24 startDrawId = lastWithdrawalDrawId + 1;
+      uint256 totalAvailable = _getTotalContributedBetween(startDrawId, endDrawId);
+      balance += _computeShutdownBalanceInRange(_vault, _account, totalAvailable, startDrawId);
+      lastWithdrawalDrawId = endDrawId;
+    }
+    
+    return uint256(balance);
+  }
+*/
+  function _computeShutdownBalanceInRange(
+    address _vault,
+    address _account,
+    uint256 liquidity,
+    uint24 startDrawIdInclusive
+  ) internal view returns (uint256) {
+      SD59x18 vaultPortion = getVaultPortion(
+        _vault,
+        startDrawIdInclusive,
+        _lastAwardedDrawId
+      );
+
+      // compute the user's share of the range
+      (uint256 _userTwab, uint256 _vaultTwabTotalSupply) = getVaultUserBalanceAndTotalSupplyTwab(
+        _vault,
+        _account,
+        startDrawIdInclusive,
+        _lastAwardedDrawId
+      );
+
+      return uint256(convert(
+        vaultPortion.mul(
+          convert(int256(_userTwab)).div(convert(int256(_vaultTwabTotalSupply)))
+        ).mul(convert(int256(liquidity)))
+      ));
+  }
+
+  function withdrawAfterShutdown(address _vault, address _account) external requireShutdown returns (uint256) {
+    // go by grand prize frequency    
+    
+    // if the user has not claimed yet, then we compute their first claim based on the 
+    
+    
+    
+    
+
+  }
+
+  function _isShutdown() internal view returns (bool) {
+    return twabController.isShutdownAt(block.timestamp) || _isInactive();
+  }
+
+  function _isInactive() internal view returns (bool) {
+    uint256 lastAwardedAtTimestamp = _lastAwardedDrawId > 0 ? lastAwardedDrawAwardedAt : firstDrawOpensAt + drawPeriodSeconds;
+
+    return block.timestamp > lastAwardedAtTimestamp + maxMissedDraws;
   }
 
   /// @notice Returns the total prize tokens contributed between the given draw ids, inclusive.
@@ -881,16 +932,6 @@ contract PrizePool is TieredLiquidityDistributor, Ownable {
   }
 
   /**
-   * @notice Transfers the given amount of prize tokens to the given address.
-   * @param _to The address to transfer to
-   * @param _amount The amount to transfer
-   */
-  function _transfer(address _to, uint256 _amount) internal {
-    _totalWithdrawn = SafeCast.toUint128(_totalWithdrawn + _amount);
-    prizeToken.safeTransfer(_to, _amount);
-  }
-
-  /**
    * @notice Checks if the given user has won the prize for the specified tier in the given vault.
    * @param _drawId The draw ID for which to check the winner
    * @param _vault The address of the vault to check
@@ -899,7 +940,6 @@ contract PrizePool is TieredLiquidityDistributor, Ownable {
    * @param _prizeIndex The prize index to check. Must be less than prize count for the tier
    * @param _vaultPortion The portion of the prizes that were contributed by the given vault
    * @param _tierOdds The tier odds to apply to make prizes less frequent
-   * @param _drawDuration The duration of prize accrual for the given tier
    * @return A boolean value indicating whether the user has won the prize or not
    */
   function _isWinner(
@@ -910,7 +950,7 @@ contract PrizePool is TieredLiquidityDistributor, Ownable {
     uint32 _prizeIndex,
     SD59x18 _vaultPortion,
     SD59x18 _tierOdds,
-    uint24 _drawDuration
+    uint24 _startDrawIdInclusive
   ) internal view returns (bool) {
     uint32 tierPrizeCount = uint32(TierCalculationLib.prizeCount(_tier));
 
@@ -926,10 +966,11 @@ contract PrizePool is TieredLiquidityDistributor, Ownable {
       _prizeIndex,
       _winningRandomNumber
     );
-    (uint256 _userTwab, uint256 _vaultTwabTotalSupply) = _getVaultUserBalanceAndTotalSupplyTwab(
+    (uint256 _userTwab, uint256 _vaultTwabTotalSupply) = getVaultUserBalanceAndTotalSupplyTwab(
       _vault,
       _user,
-      _drawDuration
+      _startDrawIdInclusive,
+      _lastAwardedDrawId
     );
 
     return
@@ -950,28 +991,29 @@ contract PrizePool is TieredLiquidityDistributor, Ownable {
    * @param lastAwardedDrawId_ The ID of the last awarded draw.
    * @return vaultPortion The portion of the prizes that are going to this vault.
    * @return tierOdds The odds of winning the prize for the given tier.
-   * @return drawDuration The duration of the draw.
    */
   function _computeVaultTierDetails(
     address _vault,
     uint8 _tier,
     uint8 _numberOfTiers,
     uint24 lastAwardedDrawId_
-  ) internal view returns (SD59x18 vaultPortion, SD59x18 tierOdds, uint24 drawDuration) {
+  ) internal view returns (SD59x18 vaultPortion, SD59x18 tierOdds, uint24 startDrawIdInclusive) {
     if (lastAwardedDrawId_ == 0) {
       revert NoDrawsAwarded();
     }
     _checkValidTier(_tier, _numberOfTiers);
 
     tierOdds = _tierOdds(_tier, _numberOfTiers);
-    drawDuration = uint24(TierCalculationLib.estimatePrizeFrequencyInDraws(tierOdds));
-    vaultPortion = _getVaultPortion(
+    startDrawIdInclusive = computeRangeStartDrawIdInclusive(lastAwardedDrawId_, uint24(TierCalculationLib.estimatePrizeFrequencyInDraws(tierOdds)));
+    vaultPortion = getVaultPortion(
       _vault,
-      SafeCast.toUint24(
-        drawDuration > lastAwardedDrawId_ ? 1 : lastAwardedDrawId_ - drawDuration + 1
-      ),
+      startDrawIdInclusive,
       lastAwardedDrawId_
     );
+  }
+
+  function computeRangeStartDrawIdInclusive(uint24 _endDrawIdInclusive, uint24 _rangeSize) public pure returns (uint24) {
+    return _rangeSize > _endDrawIdInclusive ? 1 : _endDrawIdInclusive - _rangeSize + 1;
   }
 
   /**
@@ -979,23 +1021,20 @@ contract PrizePool is TieredLiquidityDistributor, Ownable {
    * @dev This function calculates the TWAB for a user by calling the getTwabBetween function of the TWAB controller for a specified period of time.
    * @param _vault The address of the vault for which to get the TWAB.
    * @param _user The address of the user for which to get the TWAB.
-   * @param _drawDuration The duration of the period over which to calculate the TWAB, in number of draw periods.
+   * @param _startDrawIdInclusive The starting draw for the range (inclusive)
+   * @param _endDrawIdInclusive The end draw for the range (inclusive)
    * @return twab The TWAB for the specified user in the given vault over the specified period.
    * @return twabTotalSupply The TWAB total supply over the specified period.
    */
-  function _getVaultUserBalanceAndTotalSupplyTwab(
+  function getVaultUserBalanceAndTotalSupplyTwab(
     address _vault,
     address _user,
-    uint256 _drawDuration
-  ) internal view returns (uint256 twab, uint256 twabTotalSupply) {
-    uint48 _endTimestamp = _drawClosesAt(_lastAwardedDrawId);
-    uint48 _durationSeconds = SafeCast.toUint48(_drawDuration * drawPeriodSeconds);
-    uint48 _startTimestamp = _endTimestamp > _durationSeconds
-      ? _endTimestamp - _durationSeconds
-      : 0;
-
+    uint24 _startDrawIdInclusive,
+    uint24 _endDrawIdInclusive
+  ) public view returns (uint256 twab, uint256 twabTotalSupply) {
+    uint48 _startTimestamp = _drawOpensAt(_startDrawIdInclusive);
+    uint48 _endTimestamp = _drawClosesAt(_endDrawIdInclusive);
     twab = twabController.getTwabBetween(_vault, _user, _startTimestamp, _endTimestamp);
-
     twabTotalSupply = twabController.getTotalSupplyTwabBetween(
       _vault,
       _startTimestamp,
@@ -1006,20 +1045,20 @@ contract PrizePool is TieredLiquidityDistributor, Ownable {
   /**
    * @notice Calculates the portion of the vault's contribution to the prize pool over a specified duration in draws.
    * @param _vault The address of the vault for which to calculate the portion.
-   * @param _startDrawId The starting draw ID (inclusive) of the draw range to calculate the contribution portion for.
-   * @param _endDrawId The ending draw ID (inclusive) of the draw range to calculate the contribution portion for.
+   * @param _startDrawIdInclusive The starting draw ID (inclusive) of the draw range to calculate the contribution portion for.
+   * @param _endDrawIdInclusive The ending draw ID (inclusive) of the draw range to calculate the contribution portion for.
    * @return The portion of the vault's contribution to the prize pool over the specified duration in draws.
    */
-  function _getVaultPortion(
+  function getVaultPortion(
     address _vault,
-    uint24 _startDrawId,
-    uint24 _endDrawId
-  ) internal view returns (SD59x18) {
+    uint24 _startDrawIdInclusive,
+    uint24 _endDrawIdInclusive
+  ) public view returns (SD59x18) {
     SD59x18 _smoothing = smoothing.intoSD59x18();
     uint256 totalContributed = DrawAccumulatorLib.getDisbursedBetween(
       _totalAccumulator,
-      _startDrawId,
-      _endDrawId,
+      _startDrawIdInclusive,
+      _endDrawIdInclusive,
       _smoothing
     );
 
@@ -1030,12 +1069,26 @@ contract PrizePool is TieredLiquidityDistributor, Ownable {
           SafeCast.toInt256(
             DrawAccumulatorLib.getDisbursedBetween(
               _vaultAccumulator[_vault],
-              _startDrawId,
-              _endDrawId,
+              _startDrawIdInclusive,
+              _endDrawIdInclusive,
               _smoothing
             )
           )
         ).div(sd(SafeCast.toInt256(totalContributed)))
         : sd(0);
+  }
+
+  modifier notShutdown() {
+    // if (_isShutdown()) {
+    //   revert PrizePoolShutdown();
+    // }
+    _;
+  }
+
+  modifier requireShutdown() {
+    if (!_isShutdown()) {
+      revert PrizePoolNotShutdown();
+    }
+    _;
   }
 }

--- a/src/PrizePool.sol
+++ b/src/PrizePool.sol
@@ -116,6 +116,7 @@ struct ConstructorParams {
   uint8 numberOfTiers;
   uint8 tierShares;
   uint8 reserveShares;
+  uint32 maxMissedDraws;
 }
 
 /**
@@ -226,14 +227,17 @@ contract PrizePool is TieredLiquidityDistributor, Ownable {
   /// @notice The Twab Controller to use to retrieve historic balances.
   TwabController public immutable twabController;
 
-  /// @notice The draw manager address.
-  address public drawManager;
-
   /// @notice The number of seconds between draws.
   uint48 public immutable drawPeriodSeconds;
 
   /// @notice The timestamp at which the first draw will open.
   uint48 public immutable firstDrawOpensAt;
+
+  /// @notice The maximum number of draws that can be missed before the prize pool is considered inactive.
+  uint32 public immutable maxMissedDraws;
+
+  /// @notice The draw manager address.
+  address public drawManager;
 
   /// @notice The exponential weighted average of all vault contributions.
   DrawAccumulatorLib.Accumulator internal _totalAccumulator;
@@ -287,6 +291,7 @@ contract PrizePool is TieredLiquidityDistributor, Ownable {
       revert IncompatibleTwabPeriodOffset();
     }
 
+    maxMissedDraws = params.maxMissedDraws;
     prizeToken = params.prizeToken;
     twabController = params.twabController;
     smoothing = params.smoothing;

--- a/src/abstract/TieredLiquidityDistributor.sol
+++ b/src/abstract/TieredLiquidityDistributor.sol
@@ -280,11 +280,8 @@ contract TieredLiquidityDistributor {
   /// @notice Returns the estimated number of prizes for the given tier.
   /// @param _tier The tier to retrieve
   /// @return The estimated number of prizes
-  function getTierPrizeCount(uint8 _tier) external view returns (uint32) {
-    return
-      !TierCalculationLib.isValidTier(_tier, numberOfTiers)
-        ? 0
-        : uint32(TierCalculationLib.prizeCount(_tier));
+  function getTierPrizeCount(uint8 _tier) external pure returns (uint32) {
+    return uint32(TierCalculationLib.prizeCount(_tier));
   }
 
   /// @notice Retrieves an up-to-date Tier struct for the given tier.

--- a/src/abstract/TieredLiquidityDistributor.sol
+++ b/src/abstract/TieredLiquidityDistributor.sol
@@ -202,7 +202,7 @@ contract TieredLiquidityDistributor {
 
     uint8 start = _computeReclamationStart(numTiers, _nextNumberOfTiers);
     uint8 end = _nextNumberOfTiers;
-    for (uint8 i = start; i < end; i++) {
+    for (uint8 i = start; i != end; i++) {
       _tiers[i] = Tier({
         drawId: _awardingDraw,
         prizeTokenPerShare: _prizeTokenPerShare,
@@ -240,7 +240,7 @@ contract TieredLiquidityDistributor {
       // need to redistribute to the canary tier and any new tiers (if expanding)
       uint8 start = _computeReclamationStart(_numberOfTiers, _nextNumberOfTiers);
       uint8 end = _numberOfTiers;
-      for (uint8 i = start; i < end; i++) {
+      for (uint8 i = start; i != end; i++) {
         reclaimedLiquidity = reclaimedLiquidity.add(
           _getTierRemainingLiquidity(
             fromUD34x4toUD60x18(_tiers[i].prizeTokenPerShare),

--- a/src/abstract/TieredLiquidityDistributor.sol
+++ b/src/abstract/TieredLiquidityDistributor.sol
@@ -385,7 +385,7 @@ contract TieredLiquidityDistributor {
         tierShares
       );
       bool canExpand = _numberOfTiers < MAXIMUM_NUMBER_OF_TIERS;
-      if (canExpand && _isCanaryTier(_tier, _numberOfTiers)) {
+      if (canExpand && _tier == _numberOfTiers - 1) {
         // make canary prizes smaller to account for reduction in shares for next number of tiers
         prizeSize =
           (prizeSize * _getTotalShares(_numberOfTiers)) /
@@ -416,29 +416,10 @@ contract TieredLiquidityDistributor {
       );
   }
 
-  /// @notice Determines if the given tier is the canary tier.
-  /// @param _tier The tier to check
-  /// @param _numberOfTiers The current number of tiers
-  /// @return True if the tier is the canary tier
-  function _isCanaryTier(uint8 _tier, uint8 _numberOfTiers) internal pure returns (bool) {
-    return _tier == _numberOfTiers - 1;
-  }
-
   /// @notice Computes the remaining liquidity available to a tier.
   /// @param _tier The tier to compute the liquidity for
   /// @return The remaining liquidity
   function getTierRemainingLiquidity(uint8 _tier) public view returns (uint256) {
-    return _getTierRemainingLiquidity(_tier, fromUD34x4toUD60x18(prizeTokenPerShare));
-  }
-
-  /// @notice Computes the remaining liquidity available to a tier.
-  /// @param _tier The tier to compute the liquidity for
-  /// @param _prizeTokenPerShare The global prizeTokenPerShare
-  /// @return The remaining liquidity
-  function _getTierRemainingLiquidity(
-    uint8 _tier,
-    UD60x18 _prizeTokenPerShare
-  ) internal view returns (uint256) {
     uint8 _numTiers = numberOfTiers;
     return
       !TierCalculationLib.isValidTier(_tier, _numTiers)
@@ -446,7 +427,7 @@ contract TieredLiquidityDistributor {
         : convert(
           _getTierRemainingLiquidity(
             fromUD34x4toUD60x18(_getTier(_tier, _numTiers).prizeTokenPerShare),
-            _prizeTokenPerShare
+            fromUD34x4toUD60x18(prizeTokenPerShare)
           )
         );
   }

--- a/src/abstract/TieredLiquidityDistributor.sol
+++ b/src/abstract/TieredLiquidityDistributor.sol
@@ -449,14 +449,7 @@ contract TieredLiquidityDistributor {
   /// @notice Estimates the number of prizes for the current number of tiers, including the canary tier
   /// @return The estimated number of prizes including the canary tier
   function estimatedPrizeCount() external view returns (uint32) {
-    return _estimatePrizeCountPerDrawUsingNumberOfTiers(numberOfTiers);
-  }
-
-  /// @notice Estimates the number of prizes that will be awarded given a number of tiers. Includes canary tier
-  /// @param numTiers The number of tiers
-  /// @return The estimated prize count for the given number of tiers
-  function estimatedPrizeCount(uint8 numTiers) external view returns (uint32) {
-    return _estimatePrizeCountPerDrawUsingNumberOfTiers(numTiers);
+    return estimatedPrizeCount(numberOfTiers);
   }
 
   /// @notice Returns the balance of the reserve.
@@ -468,9 +461,9 @@ contract TieredLiquidityDistributor {
   /// @notice Estimates the prize count for the given tier.
   /// @param numTiers The number of prize tiers
   /// @return The estimated total number of prizes
-  function _estimatePrizeCountPerDrawUsingNumberOfTiers(
+  function estimatedPrizeCount(
     uint8 numTiers
-  ) internal view returns (uint32) {
+  ) public view returns (uint32) {
     if (numTiers == 3) {
       return ESTIMATED_PRIZES_PER_DRAW_FOR_3_TIERS;
     } else if (numTiers == 4) {
@@ -521,14 +514,6 @@ contract TieredLiquidityDistributor {
     return 10;
   }
 
-  /// @notice Computes the odds for a tier given the number of tiers.
-  /// @param _tier The tier to compute odds for
-  /// @param _numTiers The number of prize tiers
-  /// @return The odds of the tier
-  function getTierOdds(uint8 _tier, uint8 _numTiers) external view returns (SD59x18) {
-    return _tierOdds(_tier, _numTiers);
-  }
-
   /// @notice Computes the expected number of prizes for a given number of tiers.
   /// @dev Includes the canary tier
   /// @param _numTiers The number of tiers
@@ -537,7 +522,7 @@ contract TieredLiquidityDistributor {
     uint32 prizeCount;
     uint8 i = 0;
     do {
-      prizeCount += TierCalculationLib.tierPrizeCountPerDraw(i, _tierOdds(i, _numTiers));
+      prizeCount += TierCalculationLib.tierPrizeCountPerDraw(i, getTierOdds(i, _numTiers));
       i++;
     } while (i < _numTiers);
     return prizeCount;
@@ -547,7 +532,7 @@ contract TieredLiquidityDistributor {
   /// @param _tier The tier to compute odds for
   /// @param _numTiers The number of prize tiers
   /// @return The odds of the tier
-  function _tierOdds(uint8 _tier, uint8 _numTiers) internal view returns (SD59x18) {
+  function getTierOdds(uint8 _tier, uint8 _numTiers) public view returns (SD59x18) {
     if (_tier == 0) return TIER_ODDS_0;
     if (_numTiers == 3) {
       if (_tier <= 2) return TIER_ODDS_EVERY_DRAW;

--- a/src/libraries/DrawAccumulatorLib.sol
+++ b/src/libraries/DrawAccumulatorLib.sol
@@ -39,8 +39,11 @@ library DrawAccumulatorLib {
 
   /// @notice An accumulator for a draw.
   struct Accumulator {
-    RingBufferInfo ringBufferInfo;
-    uint24[366] drawRingBuffer;
+    RingBufferInfo ringBufferInfo; // 32 bits
+    uint24[366] drawRingBuffer; // 8784 bits
+    // 8784 + 32 = 8816 bits in total
+    // 256 * 35 = 8960
+    // 8960 - 8816 = 144 bits left over
     mapping(uint256 drawId => Observation observation) observations;
   }
 

--- a/test/PrizePool.t.sol
+++ b/test/PrizePool.t.sol
@@ -1447,11 +1447,8 @@ contract PrizePoolTest is Test {
     uint24 endDraw = prizePool.getLastAwardedDrawId();
     uint24 durationDraws = prizePool.getTierAccrualDurationInDraws(_tier);
     uint24 startDraw = prizePool.computeRangeStartDrawIdInclusive(endDraw, durationDraws);
-    console2.log("mockTwab ", startDraw, endDraw);
     uint48 startTime = prizePool.drawOpensAt(startDraw);
     uint48 endTime = prizePool.drawClosesAt(endDraw);
-    console2.log("Mock startTime", startTime);
-    console2.log("Mock endTime", endTime);
     mockTwab(_vault, _account, startTime, endTime);
   }
 }

--- a/test/PrizePool.t.sol
+++ b/test/PrizePool.t.sol
@@ -699,7 +699,6 @@ contract PrizePoolTest is Test {
     awardDraw(winningRandomNumber);
     contribute(100e18);
     awardDraw(winningRandomNumber);
-    (uint24 startDrawId, uint24 shutdownDrawId) = shutdownRangeDrawIds();
     
     vm.warp(firstDrawOpensAt + drawPeriodSeconds + drawTimeout);
 

--- a/test/PrizePool.t.sol
+++ b/test/PrizePool.t.sol
@@ -36,6 +36,7 @@ contract PrizePoolTest is Test {
   uint256 TIER_SHARES = 100;
   uint256 RESERVE_SHARES = 10;
 
+  uint32 maxMissedDraws = 100;
   uint24 grandPrizePeriodDraws = 365;
   uint48 firstDrawOpensAt;
   uint48 drawPeriodSeconds;
@@ -105,7 +106,8 @@ contract PrizePoolTest is Test {
       grandPrizePeriodDraws,
       initialNumberOfTiers, // minimum number of tiers
       uint8(TIER_SHARES),
-      uint8(RESERVE_SHARES)
+      uint8(RESERVE_SHARES),
+      maxMissedDraws
     );
 
     prizePool = new PrizePool(params);
@@ -594,7 +596,8 @@ contract PrizePoolTest is Test {
       grandPrizePeriodDraws,
       startingTiers, // higher number of tiers
       100,
-      10
+      10,
+      maxMissedDraws
     );
     prizePool = new PrizePool(prizePoolParams);
     prizePool.setDrawManager(address(this));
@@ -619,7 +622,8 @@ contract PrizePoolTest is Test {
       grandPrizePeriodDraws,
       startingTiers, // higher number of tiers
       100,
-      10
+      10,
+      maxMissedDraws
     );
     prizePool = new PrizePool(prizePoolParams);
     prizePool.setDrawManager(address(this));

--- a/test/PrizePool.t.sol
+++ b/test/PrizePool.t.sol
@@ -36,7 +36,7 @@ contract PrizePoolTest is Test {
   uint256 TIER_SHARES = 100;
   uint256 RESERVE_SHARES = 10;
 
-  uint32 maxMissedDraws = 100;
+  uint32 shutdownTimeout = 1000 days;
   uint24 grandPrizePeriodDraws = 365;
   uint48 firstDrawOpensAt;
   uint48 drawPeriodSeconds;
@@ -107,7 +107,7 @@ contract PrizePoolTest is Test {
       initialNumberOfTiers, // minimum number of tiers
       uint8(TIER_SHARES),
       uint8(RESERVE_SHARES),
-      maxMissedDraws
+      shutdownTimeout
     );
 
     prizePool = new PrizePool(params);
@@ -597,7 +597,7 @@ contract PrizePoolTest is Test {
       startingTiers, // higher number of tiers
       100,
       10,
-      maxMissedDraws
+      shutdownTimeout
     );
     prizePool = new PrizePool(prizePoolParams);
     prizePool.setDrawManager(address(this));
@@ -623,7 +623,7 @@ contract PrizePoolTest is Test {
       startingTiers, // higher number of tiers
       100,
       10,
-      maxMissedDraws
+      shutdownTimeout
     );
     prizePool = new PrizePool(prizePoolParams);
     prizePool.setDrawManager(address(this));

--- a/test/PrizePool.t.sol
+++ b/test/PrizePool.t.sol
@@ -13,7 +13,32 @@ import { TwabController } from "pt-v5-twab-controller/TwabController.sol";
 
 import { TierCalculationLib } from "../src/libraries/TierCalculationLib.sol";
 import { MAXIMUM_NUMBER_OF_TIERS, MINIMUM_NUMBER_OF_TIERS } from "../src/abstract/TieredLiquidityDistributor.sol";
-import { PrizePool, PrizeIsZero, ConstructorParams, InsufficientRewardsError, DidNotWin, RewardTooLarge, SmoothingGTEOne, ContributionGTDeltaBalance, InsufficientReserve, RandomNumberIsZero, AwardingDrawNotClosed, InvalidPrizeIndex, NoDrawsAwarded, InvalidTier, DrawManagerIsZeroAddress, CallerNotDrawManager, NotDeployer, RewardRecipientZeroAddress, FirstDrawOpensInPast, IncompatibleTwabPeriodLength, IncompatibleTwabPeriodOffset, ClaimPeriodExpired } from "../src/PrizePool.sol";
+import {
+  PrizePool,
+  PrizeIsZero,
+  ConstructorParams,
+  InsufficientRewardsError,
+  PrizePoolNotShutdown,
+  DidNotWin,
+  RewardTooLarge,
+  SmoothingGTEOne,
+  ContributionGTDeltaBalance,
+  InsufficientReserve,
+  RandomNumberIsZero,
+  AwardingDrawNotClosed,
+  InvalidPrizeIndex,
+  NoDrawsAwarded,
+  InvalidTier,
+  DrawManagerIsZeroAddress,
+  CallerNotDrawManager,
+  NotDeployer,
+  RewardRecipientZeroAddress,
+  FirstDrawOpensInPast,
+  IncompatibleTwabPeriodLength,
+  IncompatibleTwabPeriodOffset,
+  ClaimPeriodExpired,
+  PrizePoolShutdown
+} from "../src/PrizePool.sol";
 import { ERC20Mintable } from "./mocks/ERC20Mintable.sol";
 
 contract PrizePoolTest is Test {
@@ -36,10 +61,10 @@ contract PrizePoolTest is Test {
   uint256 TIER_SHARES = 100;
   uint256 RESERVE_SHARES = 10;
 
-  uint32 shutdownTimeout = 1000 days;
   uint24 grandPrizePeriodDraws = 365;
+  uint48 drawPeriodSeconds = 1 days;
+  uint48 drawTimeout; // = grandPrizePeriodDraws * drawPeriodSeconds; // 1000 days;
   uint48 firstDrawOpensAt;
-  uint48 drawPeriodSeconds;
   uint8 initialNumberOfTiers;
   uint256 winningRandomNumber = 123456;
   uint256 startTimestamp = 1000 days;
@@ -73,13 +98,13 @@ contract PrizePoolTest is Test {
   ConstructorParams params;
 
   function setUp() public {
+    drawTimeout = grandPrizePeriodDraws * drawPeriodSeconds;
     vm.warp(startTimestamp);
 
     prizeToken = new ERC20Mintable("PoolTogether POOL token", "POOL");
-    drawPeriodSeconds = 1 days;
-    twabController = new TwabController(uint32(drawPeriodSeconds), uint32(block.timestamp));
+    twabController = new TwabController(uint32(drawPeriodSeconds), uint32(startTimestamp - 1 days));
 
-    firstDrawOpensAt = uint48(block.timestamp + 1 days); // set draw start 1 day into future
+    firstDrawOpensAt = uint48(startTimestamp + 1 days); // set draw start 1 day into future
     initialNumberOfTiers = 3;
 
     vm.mockCall(
@@ -107,7 +132,7 @@ contract PrizePoolTest is Test {
       initialNumberOfTiers, // minimum number of tiers
       uint8(TIER_SHARES),
       uint8(RESERVE_SHARES),
-      shutdownTimeout
+      drawTimeout
     );
 
     prizePool = new PrizePool(params);
@@ -501,6 +526,30 @@ contract PrizePoolTest is Test {
     prizePool.awardDraw(winningRandomNumber);
   }
 
+  function testAwardDraw_drawTimeout() public {
+    vm.warp(firstDrawOpensAt + drawPeriodSeconds + drawTimeout);
+    vm.expectRevert(
+      abi.encodeWithSelector(
+        PrizePoolShutdown.selector
+      )
+    );
+    prizePool.awardDraw(winningRandomNumber);
+  }
+
+  function testAwardDraw_twabShutdown() public {
+    vm.mockCall(
+      address(twabController),
+      abi.encodeWithSelector(twabController.lastObservationAt.selector),
+      abi.encode(true)
+    );
+    vm.expectRevert(
+      abi.encodeWithSelector(
+        PrizePoolShutdown.selector
+      )
+    );
+    prizePool.awardDraw(winningRandomNumber);
+  }
+
   function testAwardDraw_emittedDrawIdSameAsReturnedDrawId() public {
     contribute(510e18);
     uint24 expectedDrawId = 1;
@@ -574,6 +623,203 @@ contract PrizePoolTest is Test {
     assertEq(prizePool.getTotalContributedBetween(1, 1), 10e18); // ensure not a single wei is lost!
   }
 
+  function testDrawIdPriorToShutdown_init() public {
+    params.drawTimeout = 40 * drawPeriodSeconds; // there are 40 draws within the timeframe: 1-40
+    prizePool = newPrizePool();
+    assertEq(prizePool.drawIdPriorToShutdown(), 40, "draw id is the draw that ends before/on the timeout");
+  }
+
+  function testDrawIdPriorToShutdown_shift() public {
+    params.drawTimeout = 40 * drawPeriodSeconds;
+    prizePool = newPrizePool();
+    awardDraw(winningRandomNumber);
+    assertEq(prizePool.drawIdPriorToShutdown(), 41, "draw id is the draw that ends before/on the timeout");
+  }
+
+  function testDrawTimeoutAt_init() public {
+    assertEq(prizePool.drawTimeoutAt(), firstDrawOpensAt + drawTimeout);
+  }
+
+  function testDrawTimeoutAt_oneDraw() public {
+    params.drawTimeout = 2 * drawPeriodSeconds; // once two draws have passed the prize pool is timed out
+    prizePool = newPrizePool();
+    awardDraw(winningRandomNumber);
+    assertEq(prizePool.drawTimeoutAt(), prizePool.lastAwardedDrawAwardedAt() + params.drawTimeout);
+  }
+
+  function testShutdownAt_init() public {
+    assertEq(prizePool.shutdownAt(), firstDrawOpensAt + drawTimeout);
+  }
+
+  function testShutdownAt_nearTwabEnd() public {
+    uint256 twabEnd = firstDrawOpensAt + drawTimeout/2;
+    vm.mockCall(
+      address(twabController),
+      abi.encodeCall(twabController.lastObservationAt, ()),
+      abi.encode(twabEnd)
+    );
+    vm.warp(twabEnd - drawPeriodSeconds*3);
+    awardDraw(winningRandomNumber);
+    assertEq(prizePool.shutdownAt(), twabEnd);
+  }
+
+  function testShutdownBalanceOf_notShutdown() public {
+    assertEq(prizePool.shutdownBalanceOf(address(this), msg.sender), 0);
+  }
+
+  function testShutdownBalanceOf_shutdown_noDraws_noBalance_noContributions() public {
+    vm.warp(firstDrawOpensAt + drawPeriodSeconds + drawTimeout);
+    assertEq(prizePool.shutdownBalanceOf(address(this), msg.sender), 0);
+  }
+
+  function testShutdownBalanceOf_shutdown_noDraws_withBalance_noContributions() public {
+    vm.warp(firstDrawOpensAt + drawPeriodSeconds + drawTimeout);
+    mockShutdownTwab(1e18, 1e18);
+    assertEq(prizePool.shutdownBalanceOf(address(this), msg.sender), 0);
+  }
+
+  function testShutdownBalanceOf_shutdown_noDraws_withBalance_withContributions() public {
+    contribute(100e18);
+    vm.warp(firstDrawOpensAt + drawPeriodSeconds + drawTimeout);
+    mockShutdownTwab(1e18, 1e18);
+    assertApproxEqAbs(prizePool.shutdownBalanceOf(address(this), msg.sender), 100e18, 10000);
+  }
+
+  function testShutdownBalanceOf_shutdown_noDraws_withBalance_withContributions_partial() public {
+    contribute(100e18);
+    vm.warp(firstDrawOpensAt + drawPeriodSeconds + drawTimeout);
+    mockShutdownTwab(0.5e18, 1e18);
+    assertApproxEqAbs(prizePool.shutdownBalanceOf(address(this), msg.sender), 50e18, 1000, "first claim");
+  }
+
+  function testShutdownBalanceOf_shutdown_withDraws_withBalance_withContributions() public {
+    params.drawTimeout = (grandPrizePeriodDraws/2) * drawPeriodSeconds;
+    prizePool = newPrizePool();
+    contribute(100e18);
+    awardDraw(winningRandomNumber);
+    contribute(100e18);
+    awardDraw(winningRandomNumber);
+    (uint24 startDrawId, uint24 shutdownDrawId) = shutdownRangeDrawIds();
+    
+    vm.warp(firstDrawOpensAt + drawPeriodSeconds + drawTimeout);
+
+    mockShutdownTwab(0.5e18, 1e18);
+    assertApproxEqAbs(prizePool.shutdownBalanceOf(address(this), msg.sender), 100e18, 10000);
+  }
+
+  function testShutdownBalanceOf_shutdown_withDrawsBeforeAndAfter_withBalance_withContributions() public {
+    params.smoothing = sd1x18(0);
+    prizePool = newPrizePool();
+    contribute(100e18);
+    awardDraw(winningRandomNumber);
+    contribute(100e18);
+    awardDraw(winningRandomNumber);
+    contribute(100e18);
+
+    // we want shutdown draw id === draw id to award
+    vm.warp(prizePool.lastAwardedDrawAwardedAt() + drawTimeout);
+    mockShutdownTwab(0.5e18, 1e18);
+    assertApproxEqAbs(prizePool.shutdownBalanceOf(address(this), msg.sender), 150e18, 10000);
+  }
+
+  function testShutdownBalanceOf_shutdown_noDraws_withBalance_withContributions_multiple_claims() public {
+    contribute(100e18);
+    vm.warp(firstDrawOpensAt + drawPeriodSeconds + drawTimeout);
+    mockShutdownTwab(0.5e18, 1e18);
+    vm.startPrank(msg.sender);
+    assertApproxEqAbs(prizePool.withdrawShutdownBalance(address(this), msg.sender), 50e18, 1000, "first claim");
+    vm.stopPrank();
+
+    vm.warp(firstDrawOpensAt + drawPeriodSeconds + drawTimeout + 49*drawPeriodSeconds);
+    contribute(100e18); // contributed to last closed draw.  Means 10e18 is distributed to the next draw
+    vm.warp(firstDrawOpensAt + drawPeriodSeconds + drawTimeout + 50*drawPeriodSeconds); // move forward 1 draw
+
+    // should be 50% of last amount
+    assertApproxEqAbs(prizePool.shutdownBalanceOf(address(this), msg.sender), 5e18, 1000, "second claim");
+  }
+
+  function testWithdrawShutdownBalance_notShutdown() public {
+    vm.expectRevert(abi.encodeWithSelector(PrizePoolNotShutdown.selector));
+    assertEq(prizePool.withdrawShutdownBalance(address(this), msg.sender), 0);
+  }
+
+  function testWithdrawShutdownBalance_init() public {
+    vm.warp(firstDrawOpensAt + drawTimeout);
+    assertEq(prizePool.withdrawShutdownBalance(address(this), msg.sender), 0);
+  }
+
+  function testWithdrawShutdownBalance_contributeAfterShutdown() public {
+    params.smoothing = sd1x18(0);
+    prizePool = newPrizePool();
+    vm.warp(firstDrawOpensAt + drawTimeout);
+    mockShutdownTwab(0.5e18, 1e18);
+    vm.startPrank(msg.sender);
+    assertEq(prizePool.withdrawShutdownBalance(address(this), msg.sender), 0);
+    contribute(100e18);
+    vm.warp(firstDrawOpensAt + drawTimeout + drawPeriodSeconds);
+    // they get nothing, since no one added before
+    assertEq(prizePool.withdrawShutdownBalance(address(this), msg.sender), 0);
+    vm.stopPrank();
+  }
+
+  function testWithdrawShutdownBalance_contributeBeforeAndAfterShutdown_oneClaim() public {
+    params.smoothing = sd1x18(0);
+    prizePool = newPrizePool();
+    contribute(100e18);
+    vm.warp(firstDrawOpensAt + drawTimeout);
+    mockShutdownTwab(0.5e18, 1e18);
+    vm.startPrank(msg.sender);
+    contribute(100e18);
+    vm.warp(firstDrawOpensAt + drawTimeout + drawPeriodSeconds);
+    assertEq(prizePool.withdrawShutdownBalance(address(this), msg.sender), 100e18, "second claim");
+    vm.stopPrank();
+  }
+
+  function testWithdrawShutdownBalance_contributeBeforeAndAfterShutdown_claimTwice() public {
+    params.smoothing = sd1x18(0);
+    prizePool = newPrizePool();
+    contribute(100e18);
+    vm.warp(firstDrawOpensAt + drawTimeout);
+    mockShutdownTwab(1e18, 1e18);
+    vm.startPrank(msg.sender);
+    vm.warp(firstDrawOpensAt + drawTimeout + drawPeriodSeconds);
+    assertEq(prizePool.withdrawShutdownBalance(address(this), msg.sender), 100e18, "first claim");
+    assertEq(prizePool.withdrawShutdownBalance(address(this), msg.sender), 0e18, "second claim");
+    vm.stopPrank();
+  }
+
+  function testWithdrawShutdownBalance_contributeBeforeAndAfterShutdown_twoClaim() public {
+    params.smoothing = sd1x18(0);
+    prizePool = newPrizePool();
+    contribute(100e18);
+    vm.warp(firstDrawOpensAt + drawTimeout);
+    mockShutdownTwab(0.5e18, 1e18);
+    vm.startPrank(msg.sender);
+    assertEq(prizePool.withdrawShutdownBalance(address(this), msg.sender), 50e18, "first claim");
+    contribute(100e18);
+    vm.warp(firstDrawOpensAt + drawTimeout + drawPeriodSeconds);
+    assertEq(prizePool.withdrawShutdownBalance(address(this), msg.sender), 50e18, "second claim");
+    vm.stopPrank();
+  }
+
+  function testWithdrawShutdownBalance_onShutdown() public {
+    params.smoothing = sd1x18(0);
+    prizePool = newPrizePool();
+    contribute(100e18);
+    awardDraw(winningRandomNumber);
+    contribute(100e18);
+    awardDraw(winningRandomNumber);
+    contribute(100e18);
+
+    // we want shutdown draw id === draw id to award
+    vm.warp(prizePool.lastAwardedDrawAwardedAt() + drawTimeout);
+    mockShutdownTwab(0.5e18, 1e18);
+    vm.startPrank(msg.sender);
+    assertEq(prizePool.withdrawShutdownBalance(address(this), msg.sender), 150e18);
+    assertEq(prizePool.withdrawShutdownBalance(address(this), msg.sender), 0);
+    vm.stopPrank();
+  }
+
   function testTotalContributionsForClosedDraw_noClaims() public {
     contribute(100e18);
     awardDraw(winningRandomNumber);
@@ -587,7 +833,7 @@ contract PrizePoolTest is Test {
     uint8 startingTiers = 5;
 
     // reset prize pool at higher tiers
-    ConstructorParams memory prizePoolParams = ConstructorParams(
+    params = ConstructorParams(
       prizeToken,
       twabController,
       drawPeriodSeconds,
@@ -597,10 +843,9 @@ contract PrizePoolTest is Test {
       startingTiers, // higher number of tiers
       100,
       10,
-      shutdownTimeout
+      drawTimeout
     );
-    prizePool = new PrizePool(prizePoolParams);
-    prizePool.setDrawManager(address(this));
+    prizePool = newPrizePool();
 
     contribute(510e18);
     awardDraw(1234);
@@ -613,7 +858,7 @@ contract PrizePoolTest is Test {
     uint8 startingTiers = 5;
 
     // reset prize pool at higher tiers
-    ConstructorParams memory prizePoolParams = ConstructorParams(
+    params = ConstructorParams(
       prizeToken,
       twabController,
       drawPeriodSeconds,
@@ -623,10 +868,9 @@ contract PrizePoolTest is Test {
       startingTiers, // higher number of tiers
       100,
       10,
-      shutdownTimeout
+      drawTimeout
     );
-    prizePool = new PrizePool(prizePoolParams);
-    prizePool.setDrawManager(address(this));
+    prizePool = newPrizePool();
 
     contribute(510e18);
 
@@ -1024,7 +1268,7 @@ contract PrizePoolTest is Test {
 
   function testComputeNextNumberOfTiers_drop_maxDecreaseBy1() public {
     params.numberOfTiers = 5;
-    prizePool = new PrizePool(params);
+    prizePool = newPrizePool();
     assertEq(prizePool.computeNextNumberOfTiers(0), 4);
   }
 
@@ -1443,6 +1687,18 @@ contract PrizePoolTest is Test {
     mockGetAverageTotalSupplyBetween(_vault, uint32(startTime), uint32(endTime), 1e30);
   }
 
+  function mockTwabDrawRange(address _vault, address _account, uint24 startDrawIdInclusive, uint24 endDrawIdInclusive, uint256 amount) public {
+    uint48 startTime = prizePool.drawOpensAt(startDrawIdInclusive);
+    uint48 endTime = prizePool.drawClosesAt(endDrawIdInclusive);
+    mockGetAverageBalanceBetween(_vault, _account, uint32(startTime), uint32(endTime), amount);
+  }
+
+  function mockTwabTotalSupplyDrawRange(address _vault, uint24 startDrawIdInclusive, uint24 endDrawIdInclusive, uint256 amount) public {
+    uint48 startTime = prizePool.drawOpensAt(startDrawIdInclusive);
+    uint48 endTime = prizePool.drawClosesAt(endDrawIdInclusive);
+    mockGetAverageTotalSupplyBetween(_vault, uint32(startTime), uint32(endTime), amount);
+  }
+
   function mockTwab(address _vault, address _account, uint8 _tier) public {
     uint24 endDraw = prizePool.getLastAwardedDrawId();
     uint24 durationDraws = prizePool.getTierAccrualDurationInDraws(_tier);
@@ -1450,5 +1706,28 @@ contract PrizePoolTest is Test {
     uint48 startTime = prizePool.drawOpensAt(startDraw);
     uint48 endTime = prizePool.drawClosesAt(endDraw);
     mockTwab(_vault, _account, startTime, endTime);
+  }
+
+  function grandPrizeRangeStart(uint24 endDrawIdInclusive) public view returns (uint24) {
+    return prizePool.computeRangeStartDrawIdInclusive(endDrawIdInclusive, grandPrizePeriodDraws);
+  }
+
+  function shutdownRangeDrawIds() public view returns (uint24, uint24) {
+    uint24 shutdownDrawId = prizePool.drawIdPriorToShutdown();
+    uint24 rangeStart = grandPrizeRangeStart(shutdownDrawId);
+    return (rangeStart, shutdownDrawId);
+  }
+
+  function mockShutdownTwab(uint256 userTwab, uint256 totalSupplyTwab) public {
+    (uint24 startDrawId, uint24 shutdownDrawId) = shutdownRangeDrawIds();
+    console2.log("mockShutdownTwab ", startDrawId, shutdownDrawId);
+    mockTwabDrawRange(address(this), msg.sender, startDrawId, shutdownDrawId, userTwab);
+    mockTwabTotalSupplyDrawRange(address(this), startDrawId, shutdownDrawId, totalSupplyTwab);
+  }
+
+  function newPrizePool() public returns (PrizePool) {
+    PrizePool _prizePool = new PrizePool(params);
+    _prizePool.setDrawManager(address(this));
+    return _prizePool;
   }
 }

--- a/test/abstract/TieredLiquidityDistributor.t.sol
+++ b/test/abstract/TieredLiquidityDistributor.t.sol
@@ -362,15 +362,15 @@ contract TieredLiquidityDistributorTest is Test {
   }
 
   function _computeLiquidity() internal view returns (uint256) {
-    uint256 liquidity = _getTierLiquidity(distributor.numberOfTiers(), fromUD34x4toUD60x18(distributor.prizeTokenPerShare()));
+    uint256 liquidity = _getTierLiquidity(distributor.numberOfTiers());
     liquidity += distributor.reserve();
     return liquidity;
   }
 
-  function _getTierLiquidity(uint8 _numberOfTiers, UD60x18 _prizeTokenPerShare) internal view returns (uint256) {
+  function _getTierLiquidity(uint8 _numberOfTiers) internal view returns (uint256) {
     uint256 liquidity = 0;
     for (uint8 i = 0; i < _numberOfTiers; i++) {
-      liquidity += distributor.getTierRemainingLiquidity(i, _prizeTokenPerShare);
+      liquidity += distributor.getTierRemainingLiquidity(i);
     }
     return liquidity;
   }

--- a/test/abstract/TieredLiquidityDistributor.t.sol
+++ b/test/abstract/TieredLiquidityDistributor.t.sol
@@ -241,10 +241,6 @@ contract TieredLiquidityDistributorTest is Test {
     assertEq(distributor.getTierPrizeCount(2), 16);
   }
 
-  function testGetTierPrizeCount_invalid() public {
-    assertEq(distributor.getTierPrizeCount(3), 0);
-  }
-
   function testTierOdds_zero_when_outside_bounds() public {
     SD59x18 odds;
     for (

--- a/test/abstract/helper/TieredLiquidityDistributorWrapper.sol
+++ b/test/abstract/helper/TieredLiquidityDistributorWrapper.sol
@@ -66,9 +66,4 @@ contract TieredLiquidityDistributorWrapper is TieredLiquidityDistributor {
     uint32 result = _sumTierPrizeCounts(_numTiers);
     return result;
   }
-
-  function getTierRemainingLiquidity(uint8 _tier, UD60x18 _prizeTokenPerShare) external view returns (uint256) {
-    uint256 result = _getTierRemainingLiquidity(_tier, _prizeTokenPerShare);
-    return result;
-  }
 }

--- a/test/invariants/DrawAccumulatorInvariants.t.sol
+++ b/test/invariants/DrawAccumulatorInvariants.t.sol
@@ -13,7 +13,7 @@ contract DrawAccumulatorInvariants is Test {
     accumulator = new DrawAccumulatorFuzzHarness();
   }
 
-  function testFuture_plus_past_equals_total() external {
+  function invariant_future_plus_past_equals_total() external {
     Observation memory obs = accumulator.newestObservation();
     assertEq(obs.available + obs.disbursed, accumulator.totalAdded());
   }

--- a/test/invariants/PrizePoolInvariants.t.sol
+++ b/test/invariants/PrizePoolInvariants.t.sol
@@ -1,28 +1,45 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.19;
 
-import "forge-std/Test.sol";
 import "forge-std/console2.sol";
 
 import { PrizePoolFuzzHarness } from "./helpers/PrizePoolFuzzHarness.sol";
+import { Test } from "forge-std/Test.sol";
+import { CurrentTime, CurrentTimeConsumer } from "./helpers/CurrentTimeConsumer.sol";
 
-contract PrizePoolInvariants is Test {
+contract PrizePoolInvariants is Test, CurrentTimeConsumer {
   PrizePoolFuzzHarness public prizePoolHarness;
 
   function setUp() external {
-    prizePoolHarness = new PrizePoolFuzzHarness();
-
+    currentTime = new CurrentTime(365 days);
+    prizePoolHarness = new PrizePoolFuzzHarness(currentTime);
     targetContract(address(prizePoolHarness));
   }
 
-  function invariant_balance_equals_accounted() external {
+  function invariant_balance_equals_accounted() external useCurrentTime {
     uint balance = prizePoolHarness.token().balanceOf(address(prizePoolHarness.prizePool()));
     uint accounted = prizePoolHarness.prizePool().accountedBalance();
-
-    assertEq(
-      balance,
-      accounted,
-      "balance does not match accountedBalance"
-    );
+    assertEq(balance, accounted, "balance does not match accountedBalance");
   }
+
+  // function invariant_not_shutdown() external {
+  //   assertEq(prizePoolHarness.prizePool().isShutdown(), false, "PrizePool is shutdown");
+  // }
+
+  // function test_the_thing() public {
+  //   prizePoolHarness.contributeReserve(622, 14960);
+	// 	prizePoolHarness.contributePrizeTokens(956, 23553);
+	// 	prizePoolHarness.allocateRewardFromReserve(1);
+	// 	prizePoolHarness.allocateRewardFromReserve(325742104);
+	// 	prizePoolHarness.contributeReserve(10130, 21326);
+	// 	prizePoolHarness.contributePrizeTokens(18446744073895616894, 18261);
+	// 	prizePoolHarness.claimPrizes();
+	// 	prizePoolHarness.withdrawClaimReward();
+	// 	prizePoolHarness.withdrawClaimReward();
+	// 	prizePoolHarness.contributeReserve(2281, 23443);
+	// 	prizePoolHarness.claimPrizes();
+	// 	prizePoolHarness.contributePrizeTokens(10648, 4583);
+	// 	prizePoolHarness.allocateRewardFromReserve(311);
+	// 	prizePoolHarness.contributeReserve(309485009821345068724781054, 115792089237316195423570985008687907853269984665640564039457584007913129639933);
+  // }
 }

--- a/test/invariants/helpers/CurrentTime.sol
+++ b/test/invariants/helpers/CurrentTime.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+/// @dev Because Foundry does not commit the state changes between invariant runs, we need to
+/// save the current timestamp in a contract with persistent storage.
+contract CurrentTime {
+    uint256 public timestamp;
+
+    constructor(uint256 _timestamp) {
+        timestamp = _timestamp;
+    }
+
+    function set(uint _timestamp) external {
+        timestamp = _timestamp;
+    }
+
+    function increase(uint256 _amount) external {
+        timestamp += _amount;
+    }
+}

--- a/test/invariants/helpers/CurrentTimeConsumer.sol
+++ b/test/invariants/helpers/CurrentTimeConsumer.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import { CommonBase } from "forge-std/Base.sol";
+import { CurrentTime } from "./CurrentTime.sol";
+
+contract CurrentTimeConsumer is CommonBase {
+
+    CurrentTime public currentTime;
+
+    modifier useCurrentTime() {
+        warpCurrentTime();
+        _;
+    }
+
+    modifier increaseCurrentTime(uint _amount) {
+        currentTime.increase(_amount);
+        warpCurrentTime();
+        _;
+    }
+
+    function warpTo(uint _timestamp) internal {
+        require(_timestamp > currentTime.timestamp(), "CurrentTimeConsumer/warpTo: cannot warp to the past");
+        currentTime.set(_timestamp);
+        warpCurrentTime();
+    }
+
+    function warpCurrentTime() internal {
+        vm.warp(currentTime.timestamp());
+    }
+}

--- a/test/invariants/helpers/DrawAccumulatorFuzzHarness.sol
+++ b/test/invariants/helpers/DrawAccumulatorFuzzHarness.sol
@@ -23,14 +23,10 @@ contract DrawAccumulatorFuzzHarness {
     return result;
   }
 
-  function getDisbursedBetween(uint16 _start, uint16 _end) external returns (uint256 result) {
-    // console2.log("fuzz harness 1");
+  function getDisbursedBetween(uint16 _start, uint16 _end) external view returns (uint256 result) {
     uint24 start = _start % (currentDrawId*2);
-    // console2.log("fuzz harness 2");
     uint24 end = start + _end % (currentDrawId*2);
-    // console2.log("fuzz harness 3");
     result = accumulator.getDisbursedBetween(start, end, alpha);
-    // console2.log("fuzz harness 4");
   }
 
   function newestObservation() external view returns (Observation memory) {

--- a/test/invariants/helpers/DrawAccumulatorFuzzHarness.sol
+++ b/test/invariants/helpers/DrawAccumulatorFuzzHarness.sol
@@ -13,14 +13,24 @@ contract DrawAccumulatorFuzzHarness {
 
   DrawAccumulatorLib.Accumulator internal accumulator;
 
-  uint16 currentDrawId = 1;
+  uint16 currentDrawId = uint8(uint256(blockhash(block.number - 1))) + 1;
+  SD59x18 alpha = sd(0.9e18);
 
   function add(uint88 _amount, uint8 _drawInc) public returns (bool) {
     currentDrawId += (_drawInc / 16);
-    SD59x18 alpha = sd(0.9e18);
     bool result = accumulator.add(_amount, currentDrawId, alpha);
     totalAdded += _amount;
     return result;
+  }
+
+  function getDisbursedBetween(uint16 _start, uint16 _end) external returns (uint256 result) {
+    // console2.log("fuzz harness 1");
+    uint24 start = _start % (currentDrawId*2);
+    // console2.log("fuzz harness 2");
+    uint24 end = start + _end % (currentDrawId*2);
+    // console2.log("fuzz harness 3");
+    result = accumulator.getDisbursedBetween(start, end, alpha);
+    // console2.log("fuzz harness 4");
   }
 
   function newestObservation() external view returns (Observation memory) {

--- a/test/invariants/helpers/PrizePoolFuzzHarness.sol
+++ b/test/invariants/helpers/PrizePoolFuzzHarness.sol
@@ -52,7 +52,8 @@ contract PrizePoolFuzzHarness is CommonBase, StdCheats {
       365,
       numberOfTiers,
       tierShares,
-      reserveShares
+      reserveShares,
+      100
     );
     vm.startPrank(address(this));
     prizePool = new PrizePool(params);

--- a/test/invariants/helpers/PrizePoolFuzzHarness.sol
+++ b/test/invariants/helpers/PrizePoolFuzzHarness.sol
@@ -35,7 +35,7 @@ contract PrizePoolFuzzHarness is CommonBase, StdCheats, StdUtils, CurrentTimeCon
   uint8 numberOfTiers = 3;
   uint8 tierShares = 100;
   uint8 reserveShares = 10;
-  uint48 drawTimeout = 5 * drawPeriodSeconds;
+  uint24 drawTimeout = 5;
 
   constructor(CurrentTime _currentTime) {
     currentTime = _currentTime;

--- a/test/invariants/helpers/PrizePoolFuzzHarness.sol
+++ b/test/invariants/helpers/PrizePoolFuzzHarness.sol
@@ -102,7 +102,7 @@ contract PrizePoolFuzzHarness is CommonBase, StdCheats {
               i,
               p,
               address(this),
-              1,
+              uint96(prizeSize/10),
               address(claimer)
             );
           }

--- a/test/invariants/helpers/PrizePoolFuzzHarness.sol
+++ b/test/invariants/helpers/PrizePoolFuzzHarness.sol
@@ -1,18 +1,23 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.19;
 
+import "forge-std/console2.sol";
+
 import { CommonBase } from "forge-std/Base.sol";
 import { StdCheats } from "forge-std/StdCheats.sol";
+import { StdUtils } from "forge-std/StdUtils.sol";
 import { UD2x18 } from "prb-math/UD2x18.sol";
 import { SD1x18 } from "prb-math/SD1x18.sol";
 import { TwabController } from "pt-v5-twab-controller/TwabController.sol";
 
+import { CurrentTime, CurrentTimeConsumer } from "./CurrentTimeConsumer.sol";
 import { PrizePool, ConstructorParams } from "../../../src/PrizePool.sol";
 import { ERC20Mintable } from "../../mocks/ERC20Mintable.sol";
 
-contract PrizePoolFuzzHarness is CommonBase, StdCheats {
+contract PrizePoolFuzzHarness is CommonBase, StdCheats, StdUtils, CurrentTimeConsumer {
   PrizePool public prizePool;
   ERC20Mintable public token;
+  TwabController twabController;
 
   uint256 public contributed;
   uint256 public withdrawn;
@@ -20,87 +25,160 @@ contract PrizePoolFuzzHarness is CommonBase, StdCheats {
 
   address claimer;
 
-  uint256 currentTime;
+  address[4] public actors;
+  address internal currentActor;
 
-  constructor() {
-    currentTime = 365 days;
+  address drawManager = address(this);
+  uint48 drawPeriodSeconds = 1 hours;
+  uint48 awardDrawStartsAt;
+  uint24 grandPrizePeriod = 365;
+  uint8 numberOfTiers = 3;
+  uint8 tierShares = 100;
+  uint8 reserveShares = 10;
+  uint48 drawTimeout = 5 * drawPeriodSeconds;
+
+  constructor(CurrentTime _currentTime) {
+    currentTime = _currentTime;
+    warpCurrentTime();
+    // console2.log("constructor 1");
     claimer = makeAddr("claimer");
-    address drawManager = address(this);
-    uint48 drawPeriodSeconds = 1 hours;
-    uint48 awardDrawStartsAt = uint48(currentTime);
-    uint8 numberOfTiers = 3;
-    uint8 tierShares = 100;
-    uint8 reserveShares = 10;
-    uint48 shutdownTimeout = 1000 days;
     SD1x18 smoothing = SD1x18.wrap(0.9e18);
-    
-    vm.warp(currentTime);
+    // console2.log("constructor 2");
+    for (uint i = 0; i != actors.length; i++) {
+      actors[i] = makeAddr(string(abi.encodePacked("actor", i)));
+    }
+    // console2.log("constructor 3");
+
+    // console2.log("constructor 4");
+
+    awardDrawStartsAt = uint48(currentTime.timestamp());
+
+    // console2.log("constructor 4.1");
 
     token = new ERC20Mintable("name", "SYMBOL");
-    TwabController twabController = new TwabController(
+    twabController = new TwabController(
       uint32(drawPeriodSeconds),
       uint32(awardDrawStartsAt)
     );
+    // console2.log("constructor 5");
     // arbitrary mint
     twabController.mint(address(this), 100e18);
 
+    // console2.log("constructor 6");
     ConstructorParams memory params = ConstructorParams(
       token,
       twabController,
       drawPeriodSeconds,
       awardDrawStartsAt,
       smoothing,
-      365,
+      grandPrizePeriod,
       numberOfTiers,
       tierShares,
       reserveShares,
-      shutdownTimeout
+      drawTimeout
     );
-    vm.startPrank(address(this));
+
+    // console2.log("constructor 7");
+
     prizePool = new PrizePool(params);
+
+    // console2.log("constructor 8");
+
     prizePool.setDrawManager(drawManager);
   }
 
-  function contributePrizeTokens(uint88 _amount) public warp {
-    contributed += _amount;
-    token.mint(address(prizePool), _amount);
-    prizePool.contributePrizeTokens(address(this), _amount);
+  function deposit(uint88 _amount, uint256 actorSeed) public useCurrentTime prankActor(actorSeed) {
+    twabController.mint(_actor(actorSeed), _amount);
   }
 
-  function contributeReserve(uint88 _amount) public warp {
+  function contributePrizeTokens(uint88 _amount, uint256 actorSeed) public increaseCurrentTime(_timeIncrease()) prankActor(actorSeed) {
+    // console2.log("contributePrizeTokens");
     contributed += _amount;
-    token.mint(address(this), _amount);
+    token.mint(address(prizePool), _amount);
+    prizePool.contributePrizeTokens(_actor(actorSeed), _amount);
+  }
+
+  function contributeReserve(uint88 _amount, uint256 actorSeed) public increaseCurrentTime(_timeIncrease()) prankActor(actorSeed) {
+    console2.log("CCCCCCC CONTRIBUTE");
+    if (prizePool.isShutdown()) {
+      return;
+    }
+    contributed += _amount;
+    token.mint(_actor(actorSeed), _amount);
     token.approve(address(prizePool), _amount);
     prizePool.contributeReserve(_amount);
   }
 
-  function allocateRewardFromReserve() public warp {
+  function allocateRewardFromReserve(uint256 actorSeed) public increaseCurrentTime(_timeIncrease()) prankDrawManager {
+    // console2.log("allocateRewardFromReserve");
     uint96 amount = prizePool.reserve();
     withdrawn += amount;
-    prizePool.allocateRewardFromReserve(address(msg.sender), amount);
+    prizePool.allocateRewardFromReserve(_actor(actorSeed), amount);
   }
 
-  function withdrawClaimReward() public warp {
+  function withdrawClaimReward() public increaseCurrentTime(_timeIncrease()) {
+    // console2.log("withdrawClaimReward");
     vm.startPrank(claimer);
     prizePool.withdrawRewards(address(claimer), prizePool.rewardBalance(claimer));
     vm.stopPrank();
   }
 
-  function claimPrizes() public warp {
+  function claimPrizes() public useCurrentTime {
+    console2.log("claimPrizes");
+    // console2.log("prizePool.numberOfTiers()", prizePool.numberOfTiers());
     if (prizePool.getLastAwardedDrawId() == 0) {
+      console2.log("skiipping");
       return;
     }
+    for (uint i = 0; i < actors.length; i++) {
+      _claimFor(actors[i]);
+    }
+  }
+
+  function withdrawShutdownBalance(uint256 _actorSeed) public increaseCurrentTime(_timeIncrease()) prankActor(_actorSeed) {
+    console2.log("withdrawShutdownBalance withdrawShutdownBalance withdrawShutdownBalance withdrawShutdownBalance");
+    address actor = _actor(_actorSeed);
+    if (prizePool.shutdownBalanceOf(address(this), actor) > 0) {
+      console2.log("HAS A SHUTDOWN BALANCE");
+    }
+    prizePool.withdrawShutdownBalance(address(this), actor);
+  }
+
+  function awardDraw() public useCurrentTime prankDrawManager {
+    console2.log("AWARDING");
+    uint24 drawId = prizePool.getDrawIdToAward();
+    uint256 drawToAwardClosesAt = prizePool.drawClosesAt(drawId);
+    if (drawToAwardClosesAt > currentTime.timestamp()) {
+      warpTo(drawToAwardClosesAt);
+    }
+    prizePool.awardDraw(uint256(keccak256(abi.encode(block.timestamp))));
+    console2.log("SUCCESSSSS AWARDED DRAW");
+  }
+
+  function _actor(uint256 actorIndexSeed) internal view returns (address) {
+    return actors[_bound(actorIndexSeed, 0, actors.length - 1)];
+  }
+
+  function _timeIncrease() internal view returns (uint256) {
+    uint amount = _bound(uint256(keccak256(abi.encode(block.timestamp))), 0, drawPeriodSeconds/2);
+    // console2.log("amount", amount);
+    return amount;
+  }
+
+  function _claimFor(address actor_) internal {
     uint8 numTiers = prizePool.numberOfTiers();
     for (uint8 i = 0; i < numTiers; i++) {
       for (uint32 p = 0; p < prizePool.getTierPrizeCount(i); p++) {
         if (
-          prizePool.isWinner(address(this), address(this), i, p) &&
-          !prizePool.wasClaimed(address(this), address(this), i, p)
+          prizePool.isWinner(address(this), actor_, i, p) &&
+          !prizePool.wasClaimed(address(this), actor_, i, p) &&
+          prizePool.claimCount() < 4**2 // prevent claiming all prizes
         ) {
+          console2.log("CLAIMING");
           uint256 prizeSize = prizePool.getTierPrizeSize(i);
           if (prizeSize > 0) {
             claimed += prizePool.claimPrize(
-              address(this),
+              actor_,
               i,
               p,
               address(this),
@@ -113,16 +191,16 @@ contract PrizePoolFuzzHarness is CommonBase, StdCheats {
     }
   }
 
-  function awardDraw() public warp {
-    uint256 drawToAwardClosesAt = prizePool.drawClosesAt(prizePool.getDrawIdToAward());
-    currentTime = drawToAwardClosesAt;
-    vm.warp(currentTime);
-    // vm.startPrank(address(this));
-    prizePool.awardDraw(uint256(keccak256(abi.encode(block.timestamp))));
+  modifier prankActor(uint256 actorIndexSeed) {
+    currentActor = _actor(actorIndexSeed);
+    vm.startPrank(currentActor);
+    _;
+    vm.stopPrank();
   }
 
-  modifier warp() {
-    vm.warp(currentTime);
+  modifier prankDrawManager() {
+    vm.startPrank(drawManager);
     _;
+    vm.stopPrank();
   }
 }

--- a/test/invariants/helpers/PrizePoolFuzzHarness.sol
+++ b/test/invariants/helpers/PrizePoolFuzzHarness.sol
@@ -31,6 +31,7 @@ contract PrizePoolFuzzHarness is CommonBase, StdCheats {
     uint8 numberOfTiers = 3;
     uint8 tierShares = 100;
     uint8 reserveShares = 10;
+    uint48 shutdownTimeout = 1000 days;
     SD1x18 smoothing = SD1x18.wrap(0.9e18);
     
     vm.warp(currentTime);
@@ -53,7 +54,7 @@ contract PrizePoolFuzzHarness is CommonBase, StdCheats {
       numberOfTiers,
       tierShares,
       reserveShares,
-      100
+      shutdownTimeout
     );
     vm.startPrank(address(this));
     prizePool = new PrizePool(params);

--- a/test/invariants/helpers/PrizePoolFuzzHarness.sol
+++ b/test/invariants/helpers/PrizePoolFuzzHarness.sol
@@ -89,8 +89,9 @@ contract PrizePoolFuzzHarness is CommonBase, StdCheats {
     if (prizePool.getLastAwardedDrawId() == 0) {
       return;
     }
-    for (uint8 i = 0; i < prizePool.numberOfTiers(); i++) {
-      for (uint32 p = 0; p < prizePool.getTierPrizeCount(i); i++) {
+    uint8 numTiers = prizePool.numberOfTiers();
+    for (uint8 i = 0; i < numTiers; i++) {
+      for (uint32 p = 0; p < prizePool.getTierPrizeCount(i); p++) {
         if (
           prizePool.isWinner(address(this), address(this), i, p) &&
           !prizePool.wasClaimed(address(this), address(this), i, p)

--- a/test/libraries/DrawAccumulatorLib.t.sol
+++ b/test/libraries/DrawAccumulatorLib.t.sol
@@ -307,12 +307,12 @@ contract DrawAccumulatorLibTest is Test {
     assertEq(getDisbursedBetween(6, 6), 1400);
   }
 
-  function testIntegrateInf() public {
-    assertEq(DrawAccumulatorLib.integrateInf(sd(0.9e18), 0, 100), 100);
-    assertEq(DrawAccumulatorLib.integrateInf(sd(0.9e18), 1, 100), 90);
-    assertEq(DrawAccumulatorLib.integrateInf(sd(0.9e18), 2, 100), 81);
-    assertEq(DrawAccumulatorLib.integrateInf(sd(0.9e18), 3, 100), 72);
-  }
+  // function testIntegrateInf() public {
+  //   assertEq(DrawAccumulatorLib.integrateInf(sd(0.9e18), 0, 100), 100);
+  //   assertEq(DrawAccumulatorLib.integrateInf(sd(0.9e18), 1, 100), 90);
+  //   assertEq(DrawAccumulatorLib.integrateInf(sd(0.9e18), 2, 100), 81);
+  //   assertEq(DrawAccumulatorLib.integrateInf(sd(0.9e18), 3, 100), 72);
+  // }
 
   function testIntegrate() public {
     assertEq(DrawAccumulatorLib.integrate(sd(0.9e18), 0, 1, 10000), 1000);

--- a/test/libraries/DrawAccumulatorLib.t.sol
+++ b/test/libraries/DrawAccumulatorLib.t.sol
@@ -135,6 +135,14 @@ contract DrawAccumulatorLibTest is Test {
     assertApproxEqAbs(getDisbursedBetween(1, 3), 4610, 1); // end draw ID is 1 before last observation (4)
   }
 
+  function testGetDisbursedBetween_endOneLessThanLast_alphaZero() public {
+    alpha = sd(0);
+    add(1);
+    add(2);
+    add(4);
+    assertEq(getDisbursedBetween(1, 3), 20000); // end draw ID is 1 before last observation (4)
+  }
+
   function testGetDisbursedBetween_binarySearchBothStartAndEnd() public {
     // here we want to test a case where the algorithm must binary search both the start and end observations
     add(1); // 1000

--- a/test/wrappers/DrawAccumulatorLibWrapper.sol
+++ b/test/wrappers/DrawAccumulatorLibWrapper.sol
@@ -70,7 +70,7 @@ contract DrawAccumulatorLibWrapper {
     return result;
   }
 
-  /**
+  /*
    * @notice Returns the remaining prize tokens available from relative draw _x
    */
   function integrateInf(SD59x18 _alpha, uint _x, uint _k) public pure returns (uint256) {


### PR DESCRIPTION
How it works:

Shutdown occurs when either:
- The Twab Controller is shutdown (current time exceeds the limits of the Twab)
- The draw timeout has elapsed since the last draw

The earlier of the two is the shutdown time.

If the current time is past the shutdown time, then:
- no more draws can be awarded
- vault users can withdraw their share of the prizes

Vault user's share is proportional to their contributions for the grand prize period prior to the shutdown time.