### PR TITLE
Revert if prize has already been claimed

### DIFF
--- a/src/PrizePool.sol
+++ b/src/PrizePool.sol
@@ -52,6 +52,13 @@ error InsufficientRewardsError(uint256 requested, uint256 available);
 /// @param prizeIndex The prize index
 error DidNotWin(address vault, address winner, uint8 tier, uint32 prizeIndex);
 
+/// @notice Emitted when the prize being claimed has already been claimed
+/// @param vault The vault address
+/// @param winner The address checked for the prize
+/// @param tier The prize tier
+/// @param prizeIndex The prize index
+error AlreadyClaimed(address vault, address winner, uint8 tier, uint32 prizeIndex);
+
 /// @notice Emitted when the claim reward exceeds the maximum.
 /// @param reward The reward being claimed
 /// @param maxReward The max reward that can be claimed
@@ -510,7 +517,7 @@ contract PrizePool is TieredLiquidityDistributor {
     }
 
     if (_claimedPrizes[msg.sender][_winner][lastAwardedDrawId_][_tier][_prizeIndex]) {
-      return 0;
+      revert AlreadyClaimed(msg.sender, _winner, _tier, _prizeIndex);
     }
 
     _claimedPrizes[msg.sender][_winner][lastAwardedDrawId_][_tier][_prizeIndex] = true;

--- a/test/PrizePool.t.sol
+++ b/test/PrizePool.t.sol
@@ -25,6 +25,7 @@ import {
   DrawTimeoutGTGrandPrizePeriodDraws,
   PrizePoolNotShutdown,
   DidNotWin,
+  AlreadyClaimed,
   RangeSizeZero,
   RewardTooLarge,
   ContributionGTDeltaBalance,
@@ -1294,8 +1295,9 @@ contract PrizePoolTest is Test {
     mockTwab(address(this), msg.sender, 0);
     uint256 prize = prizePool.getTierPrizeSize(0);
     assertEq(claimPrize(msg.sender, 0, 0), prize, "prize size");
-    // second claim is zero
-    assertEq(claimPrize(msg.sender, 0, 0), 0, "no more prize");
+    // second claim reverts
+    vm.expectRevert(abi.encodeWithSelector(AlreadyClaimed.selector, address(this), msg.sender, 0, 0));
+    claimPrize(msg.sender, 0, 0);
   }
 
   function testComputeNextNumberOfTiers_zero() public {


### PR DESCRIPTION
The claimer already handles claims that revert and continues with the rest of the batch, so there's no need to return zero in the prize pool when a double claim occurs. Instead, it can revert so the caller can know something wrong has occurred.

This change along with a related change in the Claimer contract will mitigate the prize vault hook claim reentrancy griefing attack.