### PR TITLE
Skip transfer if leaving rewards in prize pool

### DIFF
--- a/src/PrizePool.sol
+++ b/src/PrizePool.sol
@@ -581,7 +581,10 @@ contract PrizePool is TieredLiquidityDistributor {
     _totalWithdrawn = SafeCast.toUint128(_totalWithdrawn + _amount);
     _totalRewardsToBeClaimed = SafeCast.toUint104(_totalRewardsToBeClaimed - _amount);
 
-    prizeToken.safeTransfer(_to, _amount);
+    // skip transfer if recipient is the prize pool (tokens stay in this contract)
+    if (_to != address(this)) {
+      prizeToken.safeTransfer(_to, _amount);
+    }
 
     emit WithdrawRewards(msg.sender, _to, _amount, _available);
   }

--- a/test/PrizePool.t.sol
+++ b/test/PrizePool.t.sol
@@ -1579,6 +1579,16 @@ contract PrizePoolTest is Test {
     prizePool.withdrawRewards(address(1), 5e17);
   }
 
+  function testWithdrawRewards_transferToPrizePool() public {
+    contribute(100e18);
+    awardDraw(winningRandomNumber);
+    mockTwab(address(this), msg.sender, 0);
+    claimPrize(msg.sender, 0, 0, 1e18, address(this));
+    prizePool.withdrawRewards(address(prizePool), 1e18); // leave the tokens in the prize pool
+    assertEq(prizeToken.balanceOf(address(this)), 0);
+    assertEq(prizeToken.balanceOf(address(prizePool)) - prizePool.accountedBalance(), 1e18); // tokens are in prize pool
+  }
+
   function testDrawToAward_zeroDraw() public {
     // current time *is* lastAwardedDrawAwardedAt
     assertEq(prizePool.getDrawIdToAward(), 1);


### PR DESCRIPTION
Use case:
- DrawManager is allocating the rest of the reserve to itself and wants to contribute it on behalf of a vault
- DrawManager "withdraws" the rewards, but sets the recipient as the prize pool, so no ERC20 token transfer needs to take place and the tokens stay where they are after the accounting updates.