### PR TITLE
Align shutdown timestamp to draw period

### DIFF
--- a/src/PrizePool.sol
+++ b/src/PrizePool.sol
@@ -957,7 +957,7 @@ contract PrizePool is TieredLiquidityDistributor {
   /// @notice Returns the timestamp at which the prize pool will be considered inactive and shutdown
   /// @return The timestamp at which the prize pool will be considered inactive
   function shutdownAt() public view returns (uint256) {
-    uint256 twabShutdownAt = twabController.lastObservationAt();
+    uint256 twabShutdownAt = drawOpensAt(getDrawId(twabController.lastObservationAt()));
     uint256 drawTimeoutAt_ = drawTimeoutAt();
     return drawTimeoutAt_ < twabShutdownAt ? drawTimeoutAt_ : twabShutdownAt;
   }


### PR DESCRIPTION
The TWAB shutdown time is not guaranteed to be aligned with the prize pool draws. Since the prize pool checks shutdown status based on timestamps, it's possible that the prize pool can award a draw, have some prizes claimed, and then shutdown mid-draw. This causes issues with the shutdown portion calculation if any prizes were claimed in that time period (see original issue for more details).

To mitigate this, the TWAB shutdown timestamp is truncated to the draw period such that the prize pool is always guaranteed to be shutdown at the start of a draw.