### PR TITLE
Enforce minimum draw timeout and clarify natspec

### DIFF
--- a/src/PrizePool.sol
+++ b/src/PrizePool.sol
@@ -96,10 +96,10 @@ error InvalidPrizeIndex(uint32 invalidPrizeIndex, uint32 prizeCount, uint8 tier)
 /// @notice Thrown when there are no awarded draws when a computation requires an awarded draw.
 error NoDrawsAwarded();
 
-/// @notice Thrown when the prize pool is initialized with an invalid draw timeout.
+/// @notice Thrown when the prize pool is initialized with a draw timeout lower than the minimum.
 /// @param drawTimeout The draw timeout that was set
 /// @param minimumDrawTimeout The minimum draw timeout
-error InvalidDrawTimeout(uint24 drawTimeout, uint24 minimumDrawTimeout);
+error DrawTimeoutLtMinimum(uint24 drawTimeout, uint24 minimumDrawTimeout);
 
 /// @notice Thrown when the Prize Pool is constructed with a draw timeout greater than the grand prize period draws
 error DrawTimeoutGTGrandPrizePeriodDraws();
@@ -345,7 +345,7 @@ contract PrizePool is TieredLiquidityDistributor {
     )
   {
     if (params.drawTimeout < MINIMUM_DRAW_TIMEOUT) {
-      revert InvalidDrawTimeout(params.drawTimeout, MINIMUM_DRAW_TIMEOUT);
+      revert DrawTimeoutLtMinimum(params.drawTimeout, MINIMUM_DRAW_TIMEOUT);
     }
 
     if (params.drawTimeout > params.grandPrizePeriodDraws) {

--- a/test/PrizePool.t.sol
+++ b/test/PrizePool.t.sol
@@ -20,7 +20,8 @@ import {
   PrizeIsZero,
   ConstructorParams,
   InsufficientRewardsError,
-  DrawTimeoutIsZero,
+  InvalidDrawTimeout,
+  MINIMUM_DRAW_TIMEOUT,
   DrawTimeoutGTGrandPrizePeriodDraws,
   PrizePoolNotShutdown,
   DidNotWin,
@@ -160,9 +161,18 @@ contract PrizePoolTest is Test {
     assertEq(prizePool.drawPeriodSeconds(), drawPeriodSeconds);
   }
 
-  function testDrawTimeoutIsZero() public {
+  function testInvalidDrawTimeout() public {
     params.drawTimeout = 0;
-    vm.expectRevert(abi.encodeWithSelector(DrawTimeoutIsZero.selector));
+    vm.expectRevert(abi.encodeWithSelector(InvalidDrawTimeout.selector, 0, 2));
+    new PrizePool(params);
+
+    params.drawTimeout = 1;
+    vm.expectRevert(abi.encodeWithSelector(InvalidDrawTimeout.selector, 1, 2));
+    new PrizePool(params);
+
+    assertEq(MINIMUM_DRAW_TIMEOUT, 2); // validate assumptions
+    params.drawTimeout = 2;
+    // no revert
     new PrizePool(params);
   }
 

--- a/test/PrizePool.t.sol
+++ b/test/PrizePool.t.sol
@@ -20,7 +20,7 @@ import {
   PrizeIsZero,
   ConstructorParams,
   InsufficientRewardsError,
-  InvalidDrawTimeout,
+  DrawTimeoutLtMinimum,
   MINIMUM_DRAW_TIMEOUT,
   DrawTimeoutGTGrandPrizePeriodDraws,
   PrizePoolNotShutdown,
@@ -161,13 +161,13 @@ contract PrizePoolTest is Test {
     assertEq(prizePool.drawPeriodSeconds(), drawPeriodSeconds);
   }
 
-  function testInvalidDrawTimeout() public {
+  function testDrawTimeoutLtMinimum() public {
     params.drawTimeout = 0;
-    vm.expectRevert(abi.encodeWithSelector(InvalidDrawTimeout.selector, 0, 2));
+    vm.expectRevert(abi.encodeWithSelector(DrawTimeoutLtMinimum.selector, 0, 2));
     new PrizePool(params);
 
     params.drawTimeout = 1;
-    vm.expectRevert(abi.encodeWithSelector(InvalidDrawTimeout.selector, 1, 2));
+    vm.expectRevert(abi.encodeWithSelector(DrawTimeoutLtMinimum.selector, 1, 2));
     new PrizePool(params);
 
     assertEq(MINIMUM_DRAW_TIMEOUT, 2); // validate assumptions


### PR DESCRIPTION
The prize pool needs at least 2 draw periods since the last awarded draw to ensure there is enough time for the draw manager to award a draw; therefore the draw timeout must be at least 2 otherwise the prize pool will never award a draw and will shutdown immediately after the first draw period closes.

Also clarified the `drawTimeout` natspec to explicitly state that the value is equal to the number of draws that have passed since the last awarded draw.